### PR TITLE
AI Device Onboarding + normalizers end-to-end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+## [Unreleased] - AI Device Onboarding + Normalizers End-to-End
+
+### Added
+
+- **AI Device Onboarding** (experimental, `/AI/Onboarding/`) — discover an unmonitored SNMP device,
+  let the agent author a profile from a live walk, then review and approve before it deploys.
+  Adds `AISettings` + `DraftDefinition` models, `agent_client` (Agent Builder converse),
+  `snmp_discovery` (live grounding walk), and Generate/Approve/Reject views.
+- **Normalizers end-to-end** — authored profiles carry a `normalizers[]` array
+  (`DraftDefinition.normalizers`, migration `AI/0002`) captured from the agent and written to
+  `Profile.normalizers` on approval, so authored metrics ship scaled/decoded.
+- **KB sync tooling** (SNMP AB-tool) — `load-kb.py` gains `--prune` (exact mirror: upsert +
+  reconcile deletes) and `--check` (drift gate) so the grounding KB stays a faithful projection of
+  the repo (the source of truth). See `docs/docs/logstashui/ai-device-onboarding.md`.
+
+### Fixed
+
+- User/AI-authored profile normalizers were silently dropped from generated pipelines
+  (`_get_device_profiles` read only inline `profile_data['normalizers']`). It now falls back to the
+  `Profile.normalizers` model column, so non-official profiles ship correctly scaled metrics.
+
 ## [0.4.3] - AI Foundation, Simulation Improvements, and SNMP Fixes - 06/07/2026
 
 ### Added

--- a/docs/docs/logstashui/ai-device-onboarding.md
+++ b/docs/docs/logstashui/ai-device-onboarding.md
@@ -1,0 +1,70 @@
+# AI Device Onboarding — Build & Deploy Runbook
+
+Discover an unmonitored SNMP device → let the agent author a profile from a live walk →
+**review and approve** → deploy. This is an experimental feature (enable via
+Management → Settings → Experimental mode).
+
+## What this release adds
+
+- **AI Device Onboarding** (`/AI/Onboarding/`) — discover → author → approve → deploy, with a
+  human approval gate. `GenerateDraft` runs a live SNMP walk to ground the agent; `ApproveDraft`
+  creates the `Profile` + `DeviceTemplate` server-side and attaches them.
+- **Normalizers end-to-end** — authored profiles carry a `normalizers[]` array
+  (`multiply` / `ratio` / `translate`) captured from the agent → `DraftDefinition.normalizers` →
+  `Profile.normalizers` → the generated Logstash pipeline, so metrics ship scaled/decoded.
+- **Fix** — user/AI-authored profile normalizers are no longer dropped at pipeline generation
+  (`_get_device_profiles` now reads `Profile.normalizers`, not just inline `profile_data`).
+
+## Components (two repos)
+
+| Repo | Provides |
+|------|----------|
+| **LogstashUI** (this repo) | App: AI Onboarding models/views/UI, `agent_client`, `snmp_discovery`, the pipeline-generator normalizer fix. Migrations: `AI/0001`, `AI/0002_draftdefinition_normalizers`. |
+| **SNMP AB-tool** (`RCA/lab/snmp-ab-authoring-tool`) | The Agent Builder `snmp-profile-author` agent, the `snmp-definitions-kb` grounding KB, and the sync/deploy scripts (`deploy.sh`, `seed/load-kb.py`). |
+
+## Source of truth
+
+**LogstashUI's on-disk `src/logstashui/SNMP/data/official_profiles/*.json` are the source of truth.**
+The KB is a **derived projection**, regenerated from the repo. Never hand-edit the KB — edit the
+profiles in the repo and re-sync. The agent grounds on the KB and *reuses profile/normalizer blocks
+verbatim*, so a KB out of sync with the repo silently degrades authoring quality.
+
+## Deploy sequence
+
+1. **App** — build the image from this branch and run migrations (`python manage.py migrate` applies
+   the AI + SNMP migrations, including `DraftDefinition.normalizers`).
+2. **AI Agent Settings** — set the Agent Builder base URL, API key, and agent id
+   (`snmp-profile-author`) under AI Onboarding → AI Agent Settings (or seed `AISettings`).
+3. **Agent + tool** — from the AB-tool, deploy the agent and its `search_snmp_profiles` tool
+   (PUT-in-place, idempotent):
+   ```bash
+   ./deploy.sh          # reads .creds (ES/KB/KEY); upserts index, tool, agent — never deletes
+   ```
+4. **Sync the KB from the repo (source of truth):**
+   ```bash
+   export ES_URL="https://<cluster>.es.<region>.cloud.es.io" ES_API_KEY="<write key>"
+   python3 seed/load-kb.py --logstashui /path/to/LogstashUI --prune   # upsert + reconcile deletes = exact mirror
+   ```
+5. **Verify sync (gate — do this before using the agent):**
+   ```bash
+   python3 seed/load-kb.py --logstashui /path/to/LogstashUI --check   # prints in_sync N/N; exit 0 = OK, 1 = drift
+   ```
+6. **End-to-end check** — AI Onboarding → Generate on a candidate device → the draft shows
+   `normalizers` → Approve → Profile + Template created → Deploy from the SNMP page → confirm scaled
+   metrics land in Elasticsearch for the device IP.
+
+## Rollback
+
+The app is image-tagged; roll back by pointing the stack at the previous image tag. The KB is
+regenerable from the repo at any time (`load-kb.py --prune`), so KB state is never a rollback blocker.
+
+## Notes / known follow-ups
+
+- Official profiles are stored as **DB placeholders** (`profile_data = {'is_official_placeholder': True}`);
+  their real get/walk/table/normalizers content is read from the on-disk JSON at pipeline-gen time.
+- **Spec drift:** the on-disk profiles and the agent already use `translate` (and occasionally
+  `average`), but `gen-agent.py` pins the op set to `{multiply, ratio}` per
+  `spec/normalizers.0.5.0.json`, and the pipeline generator has no `average` handler. Reconcile
+  spec ↔ profiles ↔ generator.
+- The KB sync (`load-kb.py --prune` + `--check`) should be wired into the release/CI pipeline so the
+  KB is always a current projection of the repo.

--- a/docs/docs/logstashui/ai-device-onboarding.md
+++ b/docs/docs/logstashui/ai-device-onboarding.md
@@ -15,61 +15,45 @@ Management → Settings → Experimental mode).
 - **Fix** — user/AI-authored profile normalizers are no longer dropped at pipeline generation
   (`_get_device_profiles` now reads `Profile.normalizers`, not just inline `profile_data`).
 
-## Components (two repos)
+## Components
 
 | Repo | Provides |
 |------|----------|
-| **LogstashUI** (this repo) | App: AI Onboarding models/views/UI, `agent_client`, `snmp_discovery`, the pipeline-generator normalizer fix. Migrations: `AI/0001`, `AI/0002_draftdefinition_normalizers`. |
-| **SNMP AB-tool** (`RCA/lab/snmp-ab-authoring-tool`) | The Agent Builder `snmp-profile-author` agent, the `snmp-definitions-kb` grounding KB, and the sync/deploy scripts (`deploy.sh`, `seed/load-kb.py`). |
+| **LogstashUI** (this repo) | Everything needed at runtime: AI Onboarding models/views/UI, `agent_client`, `snmp_discovery`, `inline_grounding`, the pipeline-generator normalizer fix, AND all grounding data under `SNMP/data/` (`official_profiles/`, `official_device_templates/`, `authoring_instructions.md`, `schema_reference/`, `mib_reference/`). Migrations: `AI/0001`, `AI/0002`. |
+| **SNMP AB-tool** (`RCA/lab/snmp-ab-authoring-tool`) | **Optional — not required at runtime.** Authoring/validation tooling and the now-optional KB path (`deploy.sh`, `deploy-agent.py`, `seed/load-kb.py`) if you ever want retrieval at scale. |
 
-## Source of truth
+## Grounding is inline — no backend KB
 
-**LogstashUI's on-disk `src/logstashui/SNMP/data/official_profiles/*.json` are the source of truth.**
-The KB is a **derived projection**, regenerated from the repo. Never hand-edit the KB — edit the
-profiles in the repo and re-sync. The agent grounds on the KB and *reuses profile/normalizer blocks
-verbatim*, so a KB out of sync with the repo silently degrades authoring quality.
+The LLM is grounded **entirely from local `SNMP/data/` files, sent with each request** (converse
+`configuration_overrides`: instructions overridden, `tools: []`). There is **no `snmp-definitions-kb`,
+no search tool, and no stored-agent-prompt dependency** at runtime — so there is no backend state to
+drift. LogstashUI is the sole source of truth. `inline_grounding.py` assembles the field schema +
+standard-MIB references + generic/vendor-matched profiles (~15K tokens) per request. Agent Builder is
+just the (swappable) LLM host — `agent_client` splits `assemble_request()` (backend-agnostic) from
+`send_via_agent_builder()`, so another backend drops in without touching the app.
 
 ## Deploy sequence
 
-1. **App** — build the image from this branch and run migrations (`python manage.py migrate` applies
-   the AI + SNMP migrations, including `DraftDefinition.normalizers`).
-2. **AI Agent Settings** — set the Agent Builder base URL, API key, and agent id
-   (`snmp-profile-author`) under AI Onboarding → AI Agent Settings (or seed `AISettings`).
-3. **Agent + tool** — push the `snmp-profile-author` agent and its `search_snmp_profiles` tool
-   (PUT-in-place, idempotent, never deletes). The agent is a build artifact — deploy it with the
-   dedicated script:
-   ```bash
-   export KB_URL="https://<cluster>.kb.<region>.cloud.es.io" KB_API_KEY="<agent-builder key>"
-   python3 deploy-agent.py            # upsert tool + agent to the target cluster
-   python3 deploy-agent.py --check    # drift gate: exit 0 = in sync, 1 = differs
-   ```
-   (`deploy.sh` remains the full one-shot installer — index + tool + agent + KB seed — for a fresh
-   cluster; `deploy-agent.py` is the focused, cluster-parameterized agent push for the build/CI path.)
-4. **Sync the KB from the repo (source of truth):**
-   ```bash
-   export ES_URL="https://<cluster>.es.<region>.cloud.es.io" ES_API_KEY="<write key>"
-   python3 seed/load-kb.py --logstashui /path/to/LogstashUI --prune   # upsert + reconcile deletes = exact mirror
-   ```
-5. **Verify sync (gate — do this before using the agent):**
-   ```bash
-   python3 seed/load-kb.py --logstashui /path/to/LogstashUI --check   # prints in_sync N/N; exit 0 = OK, 1 = drift
-   ```
-6. **End-to-end check** — AI Onboarding → Generate on a candidate device → the draft shows
-   `normalizers` → Approve → Profile + Template created → Deploy from the SNMP page → confirm scaled
+1. **App** — build the image from this branch and run migrations (`python manage.py migrate`).
+2. **AI Agent Settings** — set the LLM host base URL + API key + agent id under AI Onboarding →
+   AI Agent Settings (or seed `AISettings`). No custom agent/tool/KB is required — any reachable
+   converse agent works, because the instructions are overridden per request.
+3. **End-to-end check** — AI Onboarding → Generate on a candidate → draft shows OIDs + `normalizers`
+   with few/no unverified → Approve → Profile + Template → Deploy from the SNMP page → confirm scaled
    metrics land in Elasticsearch for the device IP.
 
 ## Rollback
 
-The app is image-tagged; roll back by pointing the stack at the previous image tag. The KB is
-regenerable from the repo at any time (`load-kb.py --prune`), so KB state is never a rollback blocker.
+Image-tagged; roll back by pointing the stack at the previous image tag. No KB state to reconcile.
 
 ## Notes / known follow-ups
 
 - Official profiles are stored as **DB placeholders** (`profile_data = {'is_official_placeholder': True}`);
   their real get/walk/table/normalizers content is read from the on-disk JSON at pipeline-gen time.
-- **Spec drift:** the on-disk profiles and the agent already use `translate` (and occasionally
-  `average`), but `gen-agent.py` pins the op set to `{multiply, ratio}` per
-  `spec/normalizers.0.5.0.json`, and the pipeline generator has no `average` handler. Reconcile
-  spec ↔ profiles ↔ generator.
-- The KB sync (`load-kb.py --prune` + `--check`) should be wired into the release/CI pipeline so the
-  KB is always a current projection of the repo.
+- **Discovery** uses a column-striding walk (`AI/snmp_discovery.py`) — samples every table column so the
+  agent is grounded on complete data, not a partial walk (unit-tested in `AI/test_snmp_discovery.py`).
+- **Spec drift:** profiles/agent use `translate` (and occasionally `average`), but the pinned op set is
+  `{multiply, ratio}` and the pipeline generator has no `average` handler. Reconcile spec ↔ profiles ↔ generator.
+- **Portability (next release):** to add another LLM backend (OpenAI, local, direct inference),
+  implement one `send_via_*` alongside `send_via_agent_builder` — `assemble_request` and the app are
+  unchanged. Promote the two functions to a small backend interface when the second backend lands.

--- a/docs/docs/logstashui/ai-device-onboarding.md
+++ b/docs/docs/logstashui/ai-device-onboarding.md
@@ -35,11 +35,16 @@ verbatim*, so a KB out of sync with the repo silently degrades authoring quality
    the AI + SNMP migrations, including `DraftDefinition.normalizers`).
 2. **AI Agent Settings** — set the Agent Builder base URL, API key, and agent id
    (`snmp-profile-author`) under AI Onboarding → AI Agent Settings (or seed `AISettings`).
-3. **Agent + tool** — from the AB-tool, deploy the agent and its `search_snmp_profiles` tool
-   (PUT-in-place, idempotent):
+3. **Agent + tool** — push the `snmp-profile-author` agent and its `search_snmp_profiles` tool
+   (PUT-in-place, idempotent, never deletes). The agent is a build artifact — deploy it with the
+   dedicated script:
    ```bash
-   ./deploy.sh          # reads .creds (ES/KB/KEY); upserts index, tool, agent — never deletes
+   export KB_URL="https://<cluster>.kb.<region>.cloud.es.io" KB_API_KEY="<agent-builder key>"
+   python3 deploy-agent.py            # upsert tool + agent to the target cluster
+   python3 deploy-agent.py --check    # drift gate: exit 0 = in sync, 1 = differs
    ```
+   (`deploy.sh` remains the full one-shot installer — index + tool + agent + KB seed — for a fresh
+   cluster; `deploy-agent.py` is the focused, cluster-parameterized agent push for the build/CI path.)
 4. **Sync the KB from the repo (source of truth):**
    ```bash
    export ES_URL="https://<cluster>.es.<region>.cloud.es.io" ES_API_KEY="<write key>"

--- a/src/logstashui/AI/agent_client.py
+++ b/src/logstashui/AI/agent_client.py
@@ -1,0 +1,125 @@
+#Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+#or more contributor license agreements. Licensed under the Elastic License;
+#you may not use this file except in compliance with the Elastic License.
+"""
+Client for the external AI authoring agent (Elastic Agent Builder).
+Calls POST {agent_url}/api/agent_builder/converse and extracts the authored
+SNMP profile JSON from the response.
+"""
+import json
+import re
+import requests
+
+
+def _build_prompt(sys_descr, walk_summary, vendor, proposed_name):
+    return (
+        "You are authoring a LogstashUI SNMP profile for a newly discovered device.\n\n"
+        f"Device sysDescr:\n{sys_descr}\n\n"
+        f"Vendor (best guess): {vendor or 'unknown'}\n\n"
+        "A LIVE SNMP walk of the device returned data for the following OIDs. "
+        "Author the profile using ONLY OIDs confirmed present below (these are verified). "
+        "Prefer standard MIBs; group scalars into `get` and indexed/columnar data into `table` "
+        "with ECS-style field names.\n\n"
+        f"{walk_summary}\n\n"
+        f"Name the profile exactly: {proposed_name}\n"
+        "Return ONLY the profile JSON object with keys: name, description, vendor, product, "
+        "get, walk, table. If any OID is not confirmed by the walk above, place it under an "
+        "\"_unverified\" array instead of in get/walk/table."
+    )
+
+
+def _iter_json_objects(text):
+    """Yield JSON objects embedded anywhere in a string (handles ```json fences, prose)."""
+    dec = json.JSONDecoder()
+    for m in re.finditer(r"\{", text):
+        try:
+            obj, _ = dec.raw_decode(text[m.start():])
+            if isinstance(obj, dict):
+                yield obj
+        except Exception:
+            continue
+
+
+def _collect(node, dict_leaves, str_leaves):
+    """Recursively gather every dict and string in the response structure."""
+    if isinstance(node, dict):
+        dict_leaves.append(node)
+        for v in node.values():
+            _collect(v, dict_leaves, str_leaves)
+    elif isinstance(node, list):
+        for v in node:
+            _collect(v, dict_leaves, str_leaves)
+    elif isinstance(node, str):
+        str_leaves.append(node)
+
+
+def _is_profile(o):
+    return isinstance(o, dict) and o.get("name") and ("get" in o or "table" in o or "_unverified" in o)
+
+
+def _extract_profile(resp_json, proposed_name):
+    """Find the authored profile. The agent embeds it either as a structured dict or as
+    JSON inside an assistant-message string, so we search BOTH dict and string leaves."""
+    dict_leaves, str_leaves = [], []
+    _collect(resp_json, dict_leaves, str_leaves)
+
+    candidates = [o for o in dict_leaves if _is_profile(o)]
+    for s in str_leaves:
+        for o in _iter_json_objects(s):
+            if _is_profile(o):
+                candidates.append(o)
+
+    # 1) exact name match (the agent was told to use this exact name → the final answer)
+    for o in candidates:
+        if o.get("name") == proposed_name:
+            return o
+    # 2) richest profile-shaped object with actual OIDs
+    sized = [o for o in candidates if o.get("get") or o.get("table")]
+    if sized:
+        return max(sized, key=lambda o: len(json.dumps(o)))
+    return None
+
+
+def generate_profile(settings, *, sys_descr, walk_summary, vendor, proposed_name, timeout_s=120):
+    """
+    Returns dict: {profile_json:{get,walk,table}, unverified:[], agent_notes:str, vendor, name}
+    Raises RuntimeError on transport / auth / parse failure.
+    """
+    base = settings.agent_url.rstrip("/")
+    url = f"{base}/api/agent_builder/converse"
+    headers = {
+        "Authorization": f"ApiKey {settings.get_api_key()}",
+        "kbn-xsrf": "true",
+        "Content-Type": "application/json",
+    }
+    payload = {"agent_id": settings.agent_id,
+               "input": _build_prompt(sys_descr, walk_summary, vendor, proposed_name)}
+    r = requests.post(url, headers=headers, data=json.dumps(payload),
+                      verify=settings.verify_tls, timeout=timeout_s)
+    if r.status_code != 200:
+        raise RuntimeError(f"Agent call failed (HTTP {r.status_code}): {r.text[:300]}")
+    resp = r.json()
+    profile = _extract_profile(resp, proposed_name)
+    if not profile:
+        raise RuntimeError("Could not extract a profile from the agent response")
+
+    unverified = profile.pop("_unverified", []) or []
+    profile_json = {k: profile.get(k, {}) for k in ("get", "walk", "table")}
+    # final assistant text for provenance display
+    notes = ""
+    for o in _iter_json_objects(json.dumps(resp)):
+        pass
+    try:
+        steps = resp.get("steps", [])
+        texts = [s.get("text") or s.get("reasoning") for s in steps if isinstance(s, dict)]
+        notes = next((t for t in reversed(texts) if t), "")[:4000]
+    except Exception:
+        notes = ""
+    return {
+        "name": profile.get("name", proposed_name),
+        "vendor": profile.get("vendor", vendor),
+        "description": profile.get("description", ""),
+        "profile_json": profile_json,
+        "unverified": unverified,
+        "agent_notes": notes,
+    }

--- a/src/logstashui/AI/agent_client.py
+++ b/src/logstashui/AI/agent_client.py
@@ -105,6 +105,11 @@ def generate_profile(settings, *, sys_descr, walk_summary, vendor, proposed_name
 
     unverified = profile.pop("_unverified", []) or []
     profile_json = {k: profile.get(k, {}) for k in ("get", "walk", "table")}
+    # Carry the agent-authored normalizers so approved profiles ship SCALED metrics
+    # (paired with _get_device_profiles reading Profile.normalizers at pipeline gen).
+    normalizers = profile.get("normalizers", []) or []
+    if not isinstance(normalizers, list):
+        normalizers = []
     # final assistant text for provenance display
     notes = ""
     for o in _iter_json_objects(json.dumps(resp)):
@@ -120,6 +125,7 @@ def generate_profile(settings, *, sys_descr, walk_summary, vendor, proposed_name
         "vendor": profile.get("vendor", vendor),
         "description": profile.get("description", ""),
         "profile_json": profile_json,
+        "normalizers": normalizers,
         "unverified": unverified,
         "agent_notes": notes,
     }

--- a/src/logstashui/AI/agent_client.py
+++ b/src/logstashui/AI/agent_client.py
@@ -2,13 +2,22 @@
 #or more contributor license agreements. Licensed under the Elastic License;
 #you may not use this file except in compliance with the Elastic License.
 """
-Client for the external AI authoring agent (Elastic Agent Builder).
-Calls POST {agent_url}/api/agent_builder/converse and extracts the authored
-SNMP profile JSON from the response.
+Client for the AI SNMP profile authoring LLM.
+
+Grounding is INLINE (see inline_grounding): the authoring instructions + reference
+profiles + field schema travel with each request via converse
+`configuration_overrides`, so there is no stored-agent-prompt or KB dependency.
+
+Agent Builder is the current transport (a convenient LLM host). The split into
+assemble_request() (backend-agnostic) + send_via_agent_builder() (transport) keeps
+that seam thin, so a different LLM backend can be dropped in later without touching
+the caller (GenerateDraft) or the request assembly.
 """
 import json
 import re
 import requests
+
+from . import inline_grounding
 
 
 def _build_prompt(sys_descr, walk_summary, vendor, proposed_name):
@@ -80,11 +89,18 @@ def _extract_profile(resp_json, proposed_name):
     return None
 
 
-def generate_profile(settings, *, sys_descr, walk_summary, vendor, proposed_name, timeout_s=120):
-    """
-    Returns dict: {profile_json:{get,walk,table}, unverified:[], agent_notes:str, vendor, name}
-    Raises RuntimeError on transport / auth / parse failure.
-    """
+def assemble_request(sys_descr, walk_summary, vendor, proposed_name):
+    """Backend-agnostic: build (system_instructions, user_message). The inline
+    grounding lives in the system instructions; the per-device task is the message."""
+    system = inline_grounding.load_instructions() + "\n\n" + inline_grounding.build_grounding(vendor)
+    user = _build_prompt(sys_descr, walk_summary, vendor, proposed_name)
+    return system, user
+
+
+def send_via_agent_builder(settings, system, user, timeout_s=120):
+    """Transport (swappable). Sends an inline request to Agent Builder converse,
+    overriding the stored agent instructions and disabling tools so grounding is
+    entirely inline (no KB). Returns the parsed JSON response."""
     base = settings.agent_url.rstrip("/")
     url = f"{base}/api/agent_builder/converse"
     headers = {
@@ -92,13 +108,25 @@ def generate_profile(settings, *, sys_descr, walk_summary, vendor, proposed_name
         "kbn-xsrf": "true",
         "Content-Type": "application/json",
     }
-    payload = {"agent_id": settings.agent_id,
-               "input": _build_prompt(sys_descr, walk_summary, vendor, proposed_name)}
+    payload = {
+        "agent_id": settings.agent_id,
+        "input": user,
+        "configuration_overrides": {"instructions": system, "tools": []},
+    }
     r = requests.post(url, headers=headers, data=json.dumps(payload),
                       verify=settings.verify_tls, timeout=timeout_s)
     if r.status_code != 200:
         raise RuntimeError(f"Agent call failed (HTTP {r.status_code}): {r.text[:300]}")
-    resp = r.json()
+    return r.json()
+
+
+def generate_profile(settings, *, sys_descr, walk_summary, vendor, proposed_name, timeout_s=120):
+    """
+    Returns dict: {profile_json:{get,walk,table}, normalizers:[], unverified:[], agent_notes, vendor, name}
+    Raises RuntimeError on transport / auth / parse failure.
+    """
+    system, user = assemble_request(sys_descr, walk_summary, vendor, proposed_name)
+    resp = send_via_agent_builder(settings, system, user, timeout_s)
     profile = _extract_profile(resp, proposed_name)
     if not profile:
         raise RuntimeError("Could not extract a profile from the agent response")

--- a/src/logstashui/AI/inline_grounding.py
+++ b/src/logstashui/AI/inline_grounding.py
@@ -1,0 +1,74 @@
+#Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+#or more contributor license agreements. Licensed under the Elastic License;
+#you may not use this file except in compliance with the Elastic License.
+"""
+Inline grounding for AI SNMP profile authoring.
+
+LogstashUI is the source of truth: the authoring instructions, the field-naming
+schema, the standard-MIB references, and the reference profiles all live under
+SNMP/data/ and are sent INLINE with each authoring request. There is no backend
+grounding store (no KB) to keep in sync — the data travels with the request.
+"""
+import glob
+import json
+import os
+
+from django.conf import settings
+
+_DATA = os.path.join(settings.BASE_DIR, "SNMP", "data")
+_MAX_PROFILES = 40  # corpus is small + curated; a generous cap, not a real limit
+
+
+def _read_json(path):
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except Exception:
+        return None
+
+
+def load_instructions():
+    """The authoring prompt (source of truth), sent inline as system instructions."""
+    with open(os.path.join(_DATA, "authoring_instructions.md")) as f:
+        return f.read()
+
+
+def _relevant(profile, vendor):
+    """Keep generic/Any profiles always; vendor-specific ones only on a vendor match."""
+    pv = (profile.get("vendor") or "").strip().lower()
+    if pv in ("", "any", "generic"):
+        return True
+    v = (vendor or "").strip().lower()
+    return bool(v) and (pv in v or v in pv)
+
+
+def build_grounding(vendor):
+    """Assemble the inline grounding block from local source-of-truth files:
+    field-naming schema + standard-MIB references + relevant reference profiles."""
+    parts = []
+
+    schema = []
+    for p in sorted(glob.glob(os.path.join(_DATA, "schema_reference", "*.md"))):
+        try:
+            with open(p) as f:
+                schema.append(f.read())
+        except Exception:
+            pass
+    if schema:
+        parts.append("## FIELD NAMING SCHEMA (canonical — translate every OID to these names)\n"
+                     + "\n\n".join(schema))
+
+    mibs = [d for d in (_read_json(p) for p in
+                        sorted(glob.glob(os.path.join(_DATA, "mib_reference", "*.json")))) if d]
+    if mibs:
+        parts.append("## STANDARD-MIB REFERENCES\n" + "\n".join(json.dumps(m) for m in mibs))
+
+    profs = []
+    for p in sorted(glob.glob(os.path.join(_DATA, "official_profiles", "*.json"))):
+        d = _read_json(p)
+        if d and _relevant(d, vendor):
+            profs.append(d)
+    parts.append("## REFERENCE PROFILES (reuse OIDs / field names / normalizer blocks verbatim)\n"
+                 + "\n".join(json.dumps(p) for p in profs[:_MAX_PROFILES]))
+
+    return "\n\n".join(parts)

--- a/src/logstashui/AI/migrations/0001_initial.py
+++ b/src/logstashui/AI/migrations/0001_initial.py
@@ -1,0 +1,58 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License;
+# you may not use this file except in compliance with the Elastic License.
+
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    initial = True
+
+    dependencies = [
+        ('SNMP', '0007_remove_device_profiles'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='AISettings',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('agent_url', models.CharField(blank=True, help_text='Base Kibana URL of the Agent Builder deployment (e.g. https://my-deployment.kb.region.cloud.es.io)', max_length=512)),
+                ('agent_id', models.CharField(default='snmp-profile-author', help_text='Agent Builder agent id used to author SNMP profiles', max_length=255)),
+                ('api_key', models.CharField(blank=True, help_text="Encrypted Elasticsearch/Kibana API key (base64 'encoded' form)", max_length=1024)),
+                ('verify_tls', models.BooleanField(default=True)),
+                ('enabled', models.BooleanField(default=False)),
+                ('updated_at', models.DateTimeField(auto_now=True)),
+            ],
+            options={
+                'verbose_name': 'AI Settings',
+                'verbose_name_plural': 'AI Settings',
+            },
+        ),
+        migrations.CreateModel(
+            name='DraftDefinition',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('target_ip', models.CharField(blank=True, max_length=255)),
+                ('sys_descr', models.TextField(blank=True)),
+                ('vendor', models.CharField(blank=True, max_length=255)),
+                ('proposed_name', models.CharField(max_length=255)),
+                ('status', models.CharField(choices=[('pending', 'Pending approval'), ('approved', 'Approved'), ('rejected', 'Rejected')], default='pending', max_length=16)),
+                ('profile_json', models.JSONField(default=dict, help_text='Authored {get, walk, table} blob')),
+                ('unverified', models.JSONField(default=list, help_text='OIDs the agent could not verify')),
+                ('walk_summary', models.TextField(blank=True, help_text='OIDs found on the live snmpwalk')),
+                ('agent_notes', models.TextField(blank=True, help_text='Agent explanation / provenance')),
+                ('created_at', models.DateTimeField(auto_now_add=True)),
+                ('reviewed_at', models.DateTimeField(blank=True, null=True)),
+                ('reviewed_by', models.CharField(blank=True, max_length=255)),
+                ('created_profile', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, to='SNMP.profile')),
+                ('created_template', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, to='SNMP.devicetemplate')),
+                ('device', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='ai_drafts', to='SNMP.device')),
+            ],
+            options={
+                'ordering': ['-created_at'],
+            },
+        ),
+    ]

--- a/src/logstashui/AI/migrations/0002_draftdefinition_normalizers.py
+++ b/src/logstashui/AI/migrations/0002_draftdefinition_normalizers.py
@@ -1,0 +1,23 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License;
+# you may not use this file except in compliance with the Elastic License.
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('AI', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='draftdefinition',
+            name='normalizers',
+            field=models.JSONField(
+                default=list,
+                help_text='Authored normalizer ops (multiply/ratio/...)',
+            ),
+        ),
+    ]

--- a/src/logstashui/AI/models.py
+++ b/src/logstashui/AI/models.py
@@ -63,6 +63,7 @@ class DraftDefinition(models.Model):
     status = models.CharField(max_length=16, choices=STATUS, default="pending")
 
     profile_json = models.JSONField(default=dict, help_text="Authored {get, walk, table} blob")
+    normalizers = models.JSONField(default=list, help_text="Authored normalizer ops (multiply/ratio/...)")
     unverified = models.JSONField(default=list, help_text="OIDs the agent could not verify")
     walk_summary = models.TextField(blank=True, help_text="OIDs found on the live snmpwalk")
     agent_notes = models.TextField(blank=True, help_text="Agent explanation / provenance")

--- a/src/logstashui/AI/models.py
+++ b/src/logstashui/AI/models.py
@@ -3,5 +3,78 @@
 #you may not use this file except in compliance with the Elastic License.
 
 from django.db import models
+from Common.encryption import encrypt_credential, decrypt_credential
 
-# Create your models here.
+
+class AISettings(models.Model):
+    """
+    Connection settings for the external AI authoring agent (Elastic Agent Builder).
+    Singleton: always row pk=1.
+    """
+    agent_url = models.CharField(
+        max_length=512, blank=True,
+        help_text="Base Kibana URL of the Agent Builder deployment "
+                  "(e.g. https://my-deployment.kb.region.cloud.es.io)")
+    agent_id = models.CharField(
+        max_length=255, default="snmp-profile-author",
+        help_text="Agent Builder agent id used to author SNMP profiles")
+    api_key = models.CharField(
+        max_length=1024, blank=True,
+        help_text="Encrypted Elasticsearch/Kibana API key (base64 'encoded' form)")
+    verify_tls = models.BooleanField(default=True)
+    enabled = models.BooleanField(default=False)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        verbose_name = "AI Settings"
+        verbose_name_plural = "AI Settings"
+
+    def save(self, *args, **kwargs):
+        self.pk = 1
+        if self.api_key and not self.api_key.startswith("enc::"):
+            self.api_key = "enc::" + encrypt_credential(self.api_key)
+        super().save(*args, **kwargs)
+
+    def get_api_key(self):
+        if self.api_key and self.api_key.startswith("enc::"):
+            return decrypt_credential(self.api_key[5:])
+        return self.api_key or ""
+
+    @classmethod
+    def load(cls):
+        obj, _ = cls.objects.get_or_create(pk=1)
+        return obj
+
+
+class DraftDefinition(models.Model):
+    """
+    An AI-authored SNMP profile awaiting human approval before it becomes a
+    real Profile + DeviceTemplate. This is the approval gate for the
+    discovery -> author -> approve -> deploy loop.
+    """
+    STATUS = [("pending", "Pending approval"), ("approved", "Approved"), ("rejected", "Rejected")]
+
+    device = models.ForeignKey("SNMP.Device", on_delete=models.SET_NULL, null=True, blank=True,
+                               related_name="ai_drafts")
+    target_ip = models.CharField(max_length=255, blank=True)
+    sys_descr = models.TextField(blank=True)
+    vendor = models.CharField(max_length=255, blank=True)
+    proposed_name = models.CharField(max_length=255)
+    status = models.CharField(max_length=16, choices=STATUS, default="pending")
+
+    profile_json = models.JSONField(default=dict, help_text="Authored {get, walk, table} blob")
+    unverified = models.JSONField(default=list, help_text="OIDs the agent could not verify")
+    walk_summary = models.TextField(blank=True, help_text="OIDs found on the live snmpwalk")
+    agent_notes = models.TextField(blank=True, help_text="Agent explanation / provenance")
+
+    created_at = models.DateTimeField(auto_now_add=True)
+    reviewed_at = models.DateTimeField(null=True, blank=True)
+    reviewed_by = models.CharField(max_length=255, blank=True)
+    created_profile = models.ForeignKey("SNMP.Profile", on_delete=models.SET_NULL, null=True, blank=True)
+    created_template = models.ForeignKey("SNMP.DeviceTemplate", on_delete=models.SET_NULL, null=True, blank=True)
+
+    class Meta:
+        ordering = ["-created_at"]
+
+    def __str__(self):
+        return f"{self.proposed_name} ({self.status})"

--- a/src/logstashui/AI/snmp_discovery.py
+++ b/src/logstashui/AI/snmp_discovery.py
@@ -1,0 +1,97 @@
+#Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+#or more contributor license agreements. Licensed under the Elastic License;
+#you may not use this file except in compliance with the Elastic License.
+"""
+Live SNMP discovery walk used to GROUND the AI agent on OIDs the device actually
+exposes — so authored profiles use verified OIDs instead of guesses.
+
+Reuses the same pysnmp v3arch asyncio API as SNMP/snmp_test.py.
+"""
+import asyncio
+from pysnmp.hlapi.v3arch.asyncio import (
+    SnmpEngine, CommunityData, UdpTransportTarget, ContextData,
+    ObjectType, ObjectIdentity, get_cmd, next_cmd,
+)
+
+# Curated candidate MIB roots — broad but bounded. We only keep what returns data.
+CANDIDATE_ROOTS = {
+    "system":         "1.3.6.1.2.1.1",
+    "interfaces":     "1.3.6.1.2.1.2.2.1",
+    "interfaces_x":   "1.3.6.1.2.1.31.1.1.1",
+    "host_system":    "1.3.6.1.2.1.25.1",
+    "host_storage":   "1.3.6.1.2.1.25.2",
+    "host_processor": "1.3.6.1.2.1.25.3.3",
+    "entity_sensors": "1.3.6.1.2.1.99.1.1.1",
+    "bgp_peers":      "1.3.6.1.2.1.15.3.1",
+    "tcp":            "1.3.6.1.2.1.6",
+    "udp":            "1.3.6.1.2.1.7",
+    "ip":             "1.3.6.1.2.1.4.1",
+    "lldp_remote":    "1.0.8802.1.1.2.1.4",
+}
+MAX_LEAVES_PER_ROOT = 40
+SYS_DESCR = "1.3.6.1.2.1.1.1.0"
+
+
+def _fmt(value):
+    try:
+        return value.prettyPrint()
+    except Exception:
+        return str(value)
+
+
+def _community(community, version):
+    return CommunityData(community, mpModel=0 if str(version) == "1" else 1)
+
+
+async def _walk_root(engine, auth, transport, root):
+    found = {}
+    current = root
+    while len(found) < MAX_LEAVES_PER_ROOT:
+        ei, es, ex, var_binds = await next_cmd(
+            engine, auth, transport, ContextData(),
+            ObjectType(ObjectIdentity(current)),
+            lexicographicMode=False)
+        if ei or es or not var_binds:
+            break
+        oid, val = var_binds[0]
+        oid_str = str(oid)
+        if not oid_str.startswith(root + ".") and oid_str != root:
+            break
+        found[oid_str] = _fmt(val)
+        current = oid_str
+    return found
+
+
+async def _discover(ip, port, community, version):
+    engine = SnmpEngine()
+    auth = _community(community, version)
+    transport = await UdpTransportTarget.create((ip, int(port)))
+
+    # sysDescr first (also a reachability check)
+    ei, es, ex, vb = await get_cmd(engine, auth, transport, ContextData(),
+                                   ObjectType(ObjectIdentity(SYS_DESCR)))
+    if ei:
+        raise RuntimeError(f"SNMP unreachable: {ei}")
+    sys_descr = _fmt(vb[0][1]) if vb else ""
+
+    populated = {}
+    for name, root in CANDIDATE_ROOTS.items():
+        leaves = await _walk_root(engine, auth, transport, root)
+        if leaves:
+            populated[name] = leaves
+    return sys_descr, populated
+
+
+def discover_device(ip, port=161, community="public", version="2c", timeout_s=60):
+    """Synchronous entry point. Returns (sys_descr, populated_dict, summary_text)."""
+    sys_descr, populated = asyncio.run(asyncio.wait_for(_discover(ip, port, community, version), timeout_s))
+
+    lines = [f"sysDescr: {sys_descr}", ""]
+    for name, leaves in populated.items():
+        lines.append(f"## {name}  ({len(leaves)} OIDs returned data)")
+        for oid, val in list(leaves.items())[:12]:
+            v = (val[:60] + "…") if len(val) > 60 else val
+            lines.append(f"  {oid} = {v}")
+        lines.append("")
+    summary = "\n".join(lines)
+    return sys_descr, populated, summary

--- a/src/logstashui/AI/snmp_discovery.py
+++ b/src/logstashui/AI/snmp_discovery.py
@@ -14,13 +14,16 @@ from pysnmp.hlapi.v3arch.asyncio import (
 )
 
 # Curated candidate MIB roots — broad but bounded. We only keep what returns data.
+# Table roots are anchored at the *Entry* node so the arc immediately after the root
+# is the table COLUMN (see _walk_root's column-striding).
 CANDIDATE_ROOTS = {
     "system":         "1.3.6.1.2.1.1",
     "interfaces":     "1.3.6.1.2.1.2.2.1",
     "interfaces_x":   "1.3.6.1.2.1.31.1.1.1",
     "host_system":    "1.3.6.1.2.1.25.1",
-    "host_storage":   "1.3.6.1.2.1.25.2",
-    "host_processor": "1.3.6.1.2.1.25.3.3",
+    "host_memory":    "1.3.6.1.2.1.25.2.2",     # hrMemorySize (scalar)
+    "host_storage":   "1.3.6.1.2.1.25.2.3.1",   # hrStorageEntry
+    "host_processor": "1.3.6.1.2.1.25.3.3.1",   # hrProcessorEntry
     "entity_sensors": "1.3.6.1.2.1.99.1.1.1",
     "bgp_peers":      "1.3.6.1.2.1.15.3.1",
     "tcp":            "1.3.6.1.2.1.6",
@@ -28,7 +31,7 @@ CANDIDATE_ROOTS = {
     "ip":             "1.3.6.1.2.1.4.1",
     "lldp_remote":    "1.0.8802.1.1.2.1.4",
 }
-MAX_LEAVES_PER_ROOT = 40
+MAX_COLS_PER_ROOT = 64
 SYS_DESCR = "1.3.6.1.2.1.1.1.0"
 
 
@@ -44,9 +47,18 @@ def _community(community, version):
 
 
 async def _walk_root(engine, auth, transport, root):
+    """Column-striding walk: sample ONE representative leaf per column, then jump to
+    the NEXT column (root.<col+1>) instead of walking every row.
+
+    Row-first lexicographic walking exhausts the budget on the leading columns of
+    wide / multi-row tables, so later columns (ifOperStatus, ifHCInOctets, ...) are
+    never sampled — the agent then flags those present-but-unseen OIDs as unverified.
+    We advance by incrementing the column arc (NOT by appending a large index): some
+    agents (net-snmp) do not advance past a crafted out-of-range index and loop.
+    """
     found = {}
     current = root
-    while len(found) < MAX_LEAVES_PER_ROOT:
+    for _ in range(MAX_COLS_PER_ROOT):
         ei, es, ex, var_binds = await next_cmd(
             engine, auth, transport, ContextData(),
             ObjectType(ObjectIdentity(current)),
@@ -55,10 +67,15 @@ async def _walk_root(engine, auth, transport, root):
             break
         oid, val = var_binds[0]
         oid_str = str(oid)
-        if not oid_str.startswith(root + ".") and oid_str != root:
-            break
+        if not oid_str.startswith(root + ".") or oid_str in found:
+            break  # left the root subtree, or no forward progress
         found[oid_str] = _fmt(val)
-        current = oid_str
+        rest = oid_str[len(root) + 1:].split(".")
+        try:
+            # table cell root.<column>.<index...> — stride to the next column
+            current = f"{root}.{int(rest[0]) + 1}" if len(rest) >= 2 else oid_str
+        except ValueError:
+            current = oid_str
     return found
 
 
@@ -88,8 +105,8 @@ def discover_device(ip, port=161, community="public", version="2c", timeout_s=60
 
     lines = [f"sysDescr: {sys_descr}", ""]
     for name, leaves in populated.items():
-        lines.append(f"## {name}  ({len(leaves)} OIDs returned data)")
-        for oid, val in list(leaves.items())[:12]:
+        lines.append(f"## {name}  ({len(leaves)} columns sampled)")
+        for oid, val in leaves.items():
             v = (val[:60] + "…") if len(val) > 60 else val
             lines.append(f"  {oid} = {v}")
         lines.append("")

--- a/src/logstashui/AI/templates/ai_onboarding.html
+++ b/src/logstashui/AI/templates/ai_onboarding.html
@@ -1,0 +1,129 @@
+<!--
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+-->
+{% extends "base.html" %}
+{% block content %}
+<div class="container mx-auto px-4 py-8 max-w-7xl">
+
+  <div class="mb-6">
+    <h1 class="text-2xl font-bold">AI Device Onboarding</h1>
+    <p class="text-base-content/70">Discover an unknown device, let the agent author an SNMP definition
+       from a live walk, then <b>review and approve</b> before it deploys.</p>
+    {% if not ai_ready %}
+      <div class="alert alert-warning mt-3">AI agent not configured / disabled — set it up below.</div>
+    {% endif %}
+  </div>
+
+  <!-- AI Settings -->
+  <div class="collapse collapse-arrow bg-base-200 mb-8">
+    <input type="checkbox" {% if not ai_ready %}checked{% endif %} />
+    <div class="collapse-title font-semibold">AI Agent Settings</div>
+    <div class="collapse-content">
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
+        <label class="form-control"><span class="label-text">Agent Builder URL (kb.*)</span>
+          <input id="agent_url" class="input input-bordered" value="{{ ai_settings.agent_url }}"
+                 placeholder="https://deployment.kb.region.cloud.es.io"></label>
+        <label class="form-control"><span class="label-text">Agent id</span>
+          <input id="agent_id" class="input input-bordered" value="{{ ai_settings.agent_id }}"></label>
+        <label class="form-control"><span class="label-text">API key (encoded; leave blank to keep)</span>
+          <input id="api_key" type="password" class="input input-bordered" placeholder="••••••••"></label>
+        <div class="flex items-center gap-4 mt-6">
+          <label class="label cursor-pointer gap-2"><input id="enabled" type="checkbox" class="checkbox"
+            {% if ai_settings.enabled %}checked{% endif %}><span>Enabled</span></label>
+          <label class="label cursor-pointer gap-2"><input id="verify_tls" type="checkbox" class="checkbox"
+            {% if ai_settings.verify_tls %}checked{% endif %}><span>Verify TLS</span></label>
+        </div>
+      </div>
+      <button class="btn btn-primary mt-3" onclick="saveSettings()">Save settings</button>
+    </div>
+  </div>
+
+  <!-- Candidate devices (no template) -->
+  <h2 class="text-lg font-semibold mb-2">Devices without a definition ({{ candidates|length }})</h2>
+  <div class="overflow-x-auto mb-10">
+    <table class="table table-zebra">
+      <thead><tr><th>Device</th><th>IP</th><th>Credential</th><th></th></tr></thead>
+      <tbody>
+      {% for d in candidates %}
+        <tr>
+          <td>{{ d.name }}</td><td>{{ d.ip_address }}</td>
+          <td>{{ d.credential.name|default:"—" }}</td>
+          <td class="text-right">
+            <button class="btn btn-sm btn-primary" onclick="generate({{ d.id }}, this)">Generate with AI</button>
+          </td>
+        </tr>
+      {% empty %}
+        <tr><td colspan="4" class="text-center text-base-content/60">No undefined devices.</td></tr>
+      {% endfor %}
+      </tbody>
+    </table>
+  </div>
+
+  <!-- Approval queue -->
+  <h2 class="text-lg font-semibold mb-2">Drafts / Approval queue</h2>
+  <div class="space-y-4">
+  {% for d in drafts %}
+    <div class="card bg-base-200">
+      <div class="card-body">
+        <div class="flex items-center justify-between">
+          <div>
+            <span class="font-mono font-semibold">{{ d.proposed_name }}</span>
+            <span class="badge {% if d.status == 'pending' %}badge-warning{% elif d.status == 'approved' %}badge-success{% else %}badge-ghost{% endif %} ml-2">{{ d.status }}</span>
+            <span class="badge badge-ghost ml-1">{{ d.oid_count }} OIDs</span>
+            {% if d.unverified %}<span class="badge badge-error ml-1">{{ d.unverified|length }} unverified</span>{% endif %}
+          </div>
+          {% if d.status == 'pending' %}
+          <div class="flex gap-2">
+            <button class="btn btn-sm btn-success" onclick="review({{ d.id }}, 'Approve', this)">Approve</button>
+            <button class="btn btn-sm btn-ghost" onclick="review({{ d.id }}, 'Reject', this)">Reject</button>
+          </div>
+          {% endif %}
+        </div>
+        <div class="text-sm text-base-content/70">{{ d.target_ip }} · {{ d.vendor }} · {{ d.sys_descr|truncatechars:90 }}</div>
+        {% if d.unverified %}
+          <div class="alert alert-warning text-xs mt-2">
+            <div><b>Unverified OIDs — confirm with snmpwalk before trusting:</b>
+              <ul class="list-disc ml-5">{% for u in d.unverified %}<li>{{ u }}</li>{% endfor %}</ul></div>
+          </div>
+        {% endif %}
+        <details class="mt-2"><summary class="cursor-pointer text-sm">Show profile JSON</summary>
+          <pre class="text-xs bg-base-300 p-3 rounded mt-2 overflow-x-auto">{{ d.profile_pretty }}</pre>
+        </details>
+      </div>
+    </div>
+  {% empty %}
+    <p class="text-base-content/60">No drafts yet.</p>
+  {% endfor %}
+  </div>
+</div>
+
+<script>
+function getCookie(name){const m=document.cookie.match('(^|;)\\s*'+name+'\\s*=\\s*([^;]+)');return m?m.pop():'';}
+async function postJSON(url, body){
+  const r = await fetch(url, {method:'POST', headers:{'Content-Type':'application/json','X-CSRFToken':getCookie('csrftoken')}, body:JSON.stringify(body)});
+  return {ok:r.ok, data: await r.json().catch(()=>({}))};
+}
+async function generate(deviceId, btn){
+  btn.disabled=true; btn.textContent='Walking + authoring…';
+  const {data} = await postJSON('/AI/Onboarding/Generate/', {device_id:deviceId});
+  if(data.success){ location.reload(); } else { alert('Failed: '+(data.error||'unknown')); btn.disabled=false; btn.textContent='Generate with AI'; }
+}
+async function review(draftId, action, btn){
+  btn.disabled=true;
+  const {data} = await postJSON('/AI/Onboarding/'+action+'/', {draft_id:draftId});
+  if(data.success){ if(data.message) alert(data.message); location.reload(); } else { alert('Failed: '+(data.error||'unknown')); btn.disabled=false; }
+}
+async function saveSettings(){
+  const fd = new URLSearchParams();
+  fd.set('agent_url', document.getElementById('agent_url').value);
+  fd.set('agent_id', document.getElementById('agent_id').value);
+  fd.set('api_key', document.getElementById('api_key').value);
+  fd.set('enabled', document.getElementById('enabled').checked);
+  fd.set('verify_tls', document.getElementById('verify_tls').checked);
+  const r = await fetch('/AI/Onboarding/Settings/', {method:'POST', headers:{'Content-Type':'application/x-www-form-urlencoded','X-CSRFToken':getCookie('csrftoken')}, body:fd.toString()});
+  const data = await r.json().catch(()=>({})); alert(data.success?'Saved':'Failed: '+(data.error||'')); if(data.success) location.reload();
+}
+</script>
+{% endblock %}

--- a/src/logstashui/AI/test_inline_grounding.py
+++ b/src/logstashui/AI/test_inline_grounding.py
@@ -1,0 +1,107 @@
+#Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+#or more contributor license agreements. Licensed under the Elastic License;
+#you may not use this file except in compliance with the Elastic License.
+"""
+Unit tests for inline grounding (AI/inline_grounding.py) and the assemble/send seam
+in AI/agent_client.py. No network / no live LLM: a temp SNMP/data dir is used so the
+selection logic is deterministic.
+"""
+import json
+import os
+import tempfile
+from unittest import mock
+
+from django.test import SimpleTestCase
+
+from AI import inline_grounding as ig
+from AI import agent_client
+
+
+def _seed(tmp):
+    for sub in ("official_profiles", "schema_reference", "mib_reference"):
+        os.makedirs(os.path.join(tmp, sub))
+    with open(os.path.join(tmp, "authoring_instructions.md"), "w") as f:
+        f.write("AUTHORING RULES")
+    with open(os.path.join(tmp, "schema_reference", "s.md"), "w") as f:
+        f.write("NAMING DICT")
+    with open(os.path.join(tmp, "mib_reference", "std_x.json"), "w") as f:
+        json.dump({"name": "std_x"}, f)
+    for name, vendor in [("generic_interfaces", "Any"), ("cisco_x", "Cisco"), ("arista_x", "Arista")]:
+        with open(os.path.join(tmp, "official_profiles", f"{name}.json"), "w") as f:
+            json.dump({"name": name, "vendor": vendor, "get": {"o": "1"}}, f)
+
+
+class InlineGroundingTests(SimpleTestCase):
+    def test_relevance_rules(self):
+        self.assertTrue(ig._relevant({"vendor": "Any"}, "Arista"))       # Any always
+        self.assertTrue(ig._relevant({"vendor": ""}, "whatever"))        # blank always
+        self.assertTrue(ig._relevant({"vendor": "Arista"}, "Arista Networks EOS"))  # substring match
+        self.assertFalse(ig._relevant({"vendor": "Cisco"}, "Arista"))    # other vendor excluded
+        self.assertFalse(ig._relevant({"vendor": "Cisco"}, ""))          # no vendor -> no match
+
+    def test_grounding_includes_generic_and_vendor_match_only(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            _seed(tmp)
+            with mock.patch.object(ig, "_DATA", tmp):
+                g = ig.build_grounding("Arista Networks EOS 4.36")
+        self.assertIn("NAMING DICT", g)          # schema
+        self.assertIn("std_x", g)                # mib refs
+        self.assertIn("generic_interfaces", g)   # generic always
+        self.assertIn("arista_x", g)             # vendor match included
+        self.assertNotIn("cisco_x", g)           # other vendor excluded (no noise)
+
+    def test_grounding_has_all_sections(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            _seed(tmp)
+            with mock.patch.object(ig, "_DATA", tmp):
+                g = ig.build_grounding("Any")
+        self.assertIn("FIELD NAMING SCHEMA", g)
+        self.assertIn("STANDARD-MIB REFERENCES", g)
+        self.assertIn("REFERENCE PROFILES", g)
+
+    def test_load_instructions_reads_local_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            _seed(tmp)
+            with mock.patch.object(ig, "_DATA", tmp):
+                self.assertEqual(ig.load_instructions(), "AUTHORING RULES")
+
+
+class AssembleRequestTests(SimpleTestCase):
+    def test_grounding_goes_in_system_task_in_user(self):
+        with mock.patch.object(ig, "load_instructions", return_value="RULES"), \
+             mock.patch.object(ig, "build_grounding", return_value="GROUNDING-BLOCK"):
+            system, user = agent_client.assemble_request(
+                "Arista sysDescr", "walk-summary", "Arista", "arista_edge_ai")
+        # grounding + instructions are inline in the system prompt (no KB / no tool)
+        self.assertIn("RULES", system)
+        self.assertIn("GROUNDING-BLOCK", system)
+        # the per-device task (incl. the required profile name) is the user message
+        self.assertIn("arista_edge_ai", user)
+        self.assertIn("walk-summary", user)
+
+
+class SendViaAgentBuilderTests(SimpleTestCase):
+    def test_inline_payload_overrides_instructions_and_disables_tools(self):
+        captured = {}
+
+        class Resp:
+            status_code = 200
+            def json(self):
+                return {"ok": True}
+
+        def fake_post(url, headers=None, data=None, verify=None, timeout=None):
+            captured["url"] = url
+            captured["body"] = json.loads(data)
+            return Resp()
+
+        settings = mock.Mock(agent_url="https://kb.example", agent_id="snmp-profile-author",
+                             verify_tls=True)
+        settings.get_api_key.return_value = "k"
+        with mock.patch.object(agent_client.requests, "post", fake_post):
+            out = agent_client.send_via_agent_builder(settings, "SYS", "USER")
+        self.assertEqual(out, {"ok": True})
+        body = captured["body"]
+        self.assertEqual(body["input"], "USER")
+        self.assertEqual(body["configuration_overrides"]["instructions"], "SYS")
+        self.assertEqual(body["configuration_overrides"]["tools"], [])  # no KB tool
+        self.assertTrue(captured["url"].endswith("/api/agent_builder/converse"))

--- a/src/logstashui/AI/test_snmp_discovery.py
+++ b/src/logstashui/AI/test_snmp_discovery.py
@@ -1,0 +1,136 @@
+#Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+#or more contributor license agreements. Licensed under the Elastic License;
+#you may not use this file except in compliance with the Elastic License.
+"""
+Unit tests for the AI-onboarding SNMP discovery walk (AI/snmp_discovery.py).
+
+These use an in-memory fake SNMP agent (no live device / no network) so the
+column-striding behaviour is locked in for CI. They guard the two regressions that
+motivated the column-striding rewrite:
+  1. wide tables must be COLUMN-complete (every column sampled, not just the first few);
+  2. the walk must NOT depend on crafted out-of-range indices — net-snmp answers a
+     GETNEXT of `col.<huge>` by wrapping to the column's first row, which would loop.
+"""
+import asyncio
+from unittest import mock
+
+from django.test import SimpleTestCase
+
+from AI import snmp_discovery as sd
+
+
+def _t(oid):
+    return tuple(int(x) for x in oid.split("."))
+
+
+class FakeAgent:
+    """A minimal in-memory SNMP agent supporting GETNEXT over a fixed OID set."""
+
+    def __init__(self, leaves, wrap=False):
+        # leaves: {oid_str: value_str}
+        self.items = sorted((_t(k), k, v) for k, v in leaves.items())
+        self.wrap = wrap          # emulate net-snmp's wrap-on-out-of-range-index
+        self.requests = []        # every OID asked for (to assert the stride shape)
+
+    def getnext(self, oid):
+        self.requests.append(oid)
+        req = _t(oid)
+        if self.wrap and req and req[-1] >= 2 ** 31:
+            # net-snmp: GETNEXT of an out-of-range index returns the column's first row
+            prefix = req[:-1]
+            for t, k, v in self.items:
+                if t[:len(prefix)] == prefix and len(t) > len(prefix):
+                    return k, v
+        for t, k, v in self.items:
+            if t > req:
+                return k, v
+        return None
+
+
+def _patched(agent):
+    async def fake_next_cmd(*args, **kwargs):
+        oid = args[4]  # ObjectType(ObjectIdentity(current)) -> current (patched to str)
+        res = agent.getnext(oid)
+        if res is None:
+            return (None, 0, 0, [])
+        return (None, 0, 0, [res])   # var_binds[0] = (oid_str, value_str)
+
+    return mock.patch.multiple(
+        sd,
+        next_cmd=fake_next_cmd,
+        ObjectType=lambda x: x,
+        ObjectIdentity=lambda s: str(s),
+        ContextData=lambda: None,
+    )
+
+
+IFTABLE = "1.3.6.1.2.1.2.2.1"
+
+
+def _iftable(ncols=22, nrows=5):
+    return {f"{IFTABLE}.{c}.{r}": f"v{c}.{r}"
+            for c in range(1, ncols + 1) for r in range(1, nrows + 1)}
+
+
+class ColumnStridingWalkTests(SimpleTestCase):
+    def _walk(self, agent, root=IFTABLE):
+        with _patched(agent):
+            return asyncio.run(sd._walk_root(None, None, None, root))
+
+    def test_samples_every_column_exactly_once(self):
+        agent = FakeAgent(_iftable(22, 5))
+        found = self._walk(agent)
+        cols = sorted({k[len(IFTABLE) + 1:].split(".")[0] for k in found}, key=int)
+        self.assertEqual(len(found), 22, "should sample one leaf per column")
+        self.assertEqual(cols, [str(i) for i in range(1, 23)], "all 22 columns covered")
+
+    def test_stride_increments_column_and_never_crafts_large_index(self):
+        agent = FakeAgent(_iftable(22, 5))
+        self._walk(agent)
+        rootlen = len(_t(IFTABLE))
+        for oid in agent.requests:
+            arcs = _t(oid)
+            self.assertTrue(all(a < 2 ** 32 for a in arcs),
+                            f"out-of-range OID arc requested: {oid}")
+            if oid != IFTABLE:
+                extra = arcs[rootlen:]
+                self.assertEqual(len(extra), 1,
+                                 f"column advance must be root.<col>, got {oid}")
+
+    def test_full_coverage_on_netsnmp_wrapping_agent(self):
+        # If the walk ever appended a large index it would loop here and miss columns.
+        agent = FakeAgent(_iftable(22, 5), wrap=True)
+        found = self._walk(agent)
+        self.assertEqual(len(found), 22, "column stride must not rely on out-of-range indices")
+
+    def test_terminates_and_respects_column_cap(self):
+        agent = FakeAgent(_iftable(200, 2))  # more columns than MAX_COLS_PER_ROOT
+        found = self._walk(agent)
+        self.assertLessEqual(len(found), sd.MAX_COLS_PER_ROOT)
+
+    def test_scalar_group_samples_each_scalar(self):
+        root = "1.3.6.1.2.1.1"
+        agent = FakeAgent({f"{root}.{i}.0": f"s{i}" for i in range(1, 10)})
+        found = self._walk(agent, root)
+        self.assertEqual(len(found), 9)
+
+    def test_stops_when_leaving_the_root_subtree(self):
+        leaves = _iftable(3, 2)
+        leaves["1.3.6.1.2.1.2.2.2.1"] = "sibling"  # outside IFTABLE
+        agent = FakeAgent(leaves)
+        found = self._walk(agent)
+        self.assertTrue(all(k.startswith(IFTABLE + ".") for k in found))
+
+
+class DiscoverSummaryTests(SimpleTestCase):
+    def test_summary_lists_all_columns_not_truncated(self):
+        # Regression guard for the old `list(leaves.items())[:12]` cap.
+        pop = {"interfaces": {f"{IFTABLE}.{c}.1": f"v{c}" for c in range(1, 23)}}
+
+        async def fake_discover(ip, port, community, version):
+            return "FakeOS 1.0", pop
+
+        with mock.patch.object(sd, "_discover", fake_discover):
+            _, _, summary = sd.discover_device("192.0.2.1")
+        listed = [l for l in summary.splitlines() if l.strip().startswith(IFTABLE)]
+        self.assertEqual(len(listed), 22, "summary must not truncate columns")

--- a/src/logstashui/AI/urls.py
+++ b/src/logstashui/AI/urls.py
@@ -13,4 +13,11 @@ urlpatterns = [
     path("IntegrationFactory/generate/", integration_factory.generate_integration, name="GenerateIntegration"),
     path("IntegrationFactory/delete/", integration_factory.delete_integration_assets, name="DeleteIntegrationAssets"),
     path("IntegrationFactory/install-prebuilt/", integration_factory.install_prebuilt_integration, name="InstallPrebuiltIntegration"),
+
+    # AI-assisted SNMP device onboarding (discover -> author -> approve -> deploy)
+    path("Onboarding/", views.AIOnboarding, name="AIOnboarding"),
+    path("Onboarding/Settings/", views.SaveAISettings, name="SaveAISettings"),
+    path("Onboarding/Generate/", views.GenerateDraft, name="GenerateDraft"),
+    path("Onboarding/Approve/", views.ApproveDraft, name="ApproveDraft"),
+    path("Onboarding/Reject/", views.RejectDraft, name="RejectDraft"),
 ]

--- a/src/logstashui/AI/views.py
+++ b/src/logstashui/AI/views.py
@@ -128,6 +128,7 @@ def GenerateDraft(request):
         draft = DraftDefinition.objects.create(
             device=device, target_ip=device.ip_address, sys_descr=sys_descr, vendor=result["vendor"],
             proposed_name=result["name"], status="pending", profile_json=result["profile_json"],
+            normalizers=result.get("normalizers", []),
             unverified=result["unverified"], walk_summary=summary, agent_notes=result["agent_notes"])
         return JsonResponse({"success": True, "draft_id": draft.id,
                              "unverified_count": len(result["unverified"])})
@@ -156,7 +157,8 @@ def ApproveDraft(request):
 
         profile = Profile.objects.create(
             name=draft.proposed_name, description=f"[AI-authored] {draft.vendor}".strip(),
-            vendor=draft.vendor or "", product="", profile_data=draft.profile_json)
+            vendor=draft.vendor or "", product="", profile_data=draft.profile_json,
+            normalizers=draft.normalizers or [])
 
         tpl_name = f"{draft.proposed_name}_template"
         template = DeviceTemplate.objects.create(

--- a/src/logstashui/AI/views.py
+++ b/src/logstashui/AI/views.py
@@ -2,15 +2,196 @@
 #or more contributor license agreements. Licensed under the Elastic License;
 #you may not use this file except in compliance with the Elastic License.
 
+import json
+import re
+import logging
+
+from django.http import JsonResponse
 from django.shortcuts import render
+from django.utils import timezone
+from django.views.decorators.http import require_http_methods
+
 from PipelineManager.models import Connection
+from Common.decorators import require_admin_role
+from SNMP.models import Device, Profile, DeviceTemplate
+from .models import AISettings, DraftDefinition
+from . import snmp_discovery, agent_client
+
+logger = logging.getLogger(__name__)
+
 
 def IntegrationFactory(request):
     connections = Connection.objects.filter(
         connection_type=Connection.ConnectionType.CENTRALIZED,
         cloud_id__isnull=False
     ).exclude(cloud_id='').values('id', 'name')
-    
+
     return render(request, 'integration_factory.html', {
         'connections': connections
     })
+
+
+def _slug(s):
+    return re.sub(r"[^a-z0-9]+", "_", (s or "").lower()).strip("_") or "device"
+
+
+def IntegrationFactory(request):
+    return render(request, "integration_factory.html")
+
+
+def _oid_count(pj):
+    n = len(pj.get("get", {})) + len(pj.get("walk", {}))
+    for t in (pj.get("table", {}) or {}).values():
+        n += len((t or {}).get("columns", {}))
+    return n
+
+
+def _ip_already_monitored(ip_address, exclude_device_id=None):
+    """True if another device with this IP already has a template (i.e. is being monitored)."""
+    qs = Device.objects.filter(ip_address=ip_address, device_template__isnull=False)
+    if exclude_device_id:
+        qs = qs.exclude(pk=exclude_device_id)
+    return qs.exists()
+
+
+def AIOnboarding(request):
+    """Approval-queue UI: candidate devices (no template) + drafts to review."""
+    # Candidates = devices with no template AND whose IP isn't already monitored by another
+    # device (check B — don't offer to onboard a device that's effectively already covered).
+    monitored_ips = set(Device.objects.filter(device_template__isnull=False)
+                        .values_list("ip_address", flat=True))
+    candidates = (Device.objects.filter(device_template__isnull=True)
+                  .exclude(ip_address__in=monitored_ips)
+                  .select_related("credential", "network"))
+    drafts = list(DraftDefinition.objects.all()[:50])
+    for d in drafts:
+        d.oid_count = _oid_count(d.profile_json or {})
+        d.profile_pretty = json.dumps(d.profile_json or {}, indent=2)
+    settings_obj = AISettings.load()
+    return render(request, "ai_onboarding.html", {
+        "candidates": candidates,
+        "drafts": drafts,
+        "ai_settings": settings_obj,
+        "ai_ready": bool(settings_obj.enabled and settings_obj.agent_url and settings_obj.api_key),
+    })
+
+
+@require_admin_role
+@require_http_methods(["POST"])
+def SaveAISettings(request):
+    s = AISettings.load()
+    s.agent_url = request.POST.get("agent_url", "").strip()
+    s.agent_id = request.POST.get("agent_id", "snmp-profile-author").strip() or "snmp-profile-author"
+    key = request.POST.get("api_key", "").strip()
+    if key:                       # only overwrite if a new key was entered
+        s.api_key = key
+    s.verify_tls = request.POST.get("verify_tls", "true") == "true"
+    s.enabled = request.POST.get("enabled", "false") == "true"
+    s.save()
+    return JsonResponse({"success": True, "message": "AI settings saved"})
+
+
+@require_admin_role
+@require_http_methods(["POST"])
+def GenerateDraft(request):
+    """Walk a device live, ask the agent to author a profile, store as pending draft."""
+    try:
+        device_id = json.loads(request.body).get("device_id")
+        device = Device.objects.select_related("credential", "network").get(pk=device_id)
+        cred = device.credential or (device.network.credential if device.network else None)
+        if not cred:
+            return JsonResponse({"success": False, "error": "Device has no SNMP credential"}, status=400)
+
+        # Check B: don't onboard an IP that's already monitored by another device.
+        if _ip_already_monitored(device.ip_address, exclude_device_id=device.id):
+            return JsonResponse({"success": False, "error":
+                f"IP {device.ip_address} is already monitored by another device — onboarding skipped "
+                f"to avoid a duplicate/overlapping definition."}, status=400)
+
+        settings_obj = AISettings.load()
+        if not (settings_obj.enabled and settings_obj.agent_url and settings_obj.api_key):
+            return JsonResponse({"success": False, "error": "AI agent not configured (see AI Settings)"}, status=400)
+
+        # 1) live discovery walk -> verified OIDs
+        community = cred.get_community() if cred.version in ("1", "2c") else "public"
+        sys_descr, populated, summary = snmp_discovery.discover_device(
+            device.ip_address, device.port or 161, community, cred.version)
+
+        vendor = sys_descr.split()[0] if sys_descr else ""
+        proposed = f"{_slug(vendor)}_{_slug(device.name)}_ai"
+
+        # 2) author via the agent, grounded on the walk
+        result = agent_client.generate_profile(
+            settings_obj, sys_descr=sys_descr, walk_summary=summary,
+            vendor=vendor, proposed_name=proposed)
+
+        draft = DraftDefinition.objects.create(
+            device=device, target_ip=device.ip_address, sys_descr=sys_descr, vendor=result["vendor"],
+            proposed_name=result["name"], status="pending", profile_json=result["profile_json"],
+            unverified=result["unverified"], walk_summary=summary, agent_notes=result["agent_notes"])
+        return JsonResponse({"success": True, "draft_id": draft.id,
+                             "unverified_count": len(result["unverified"])})
+    except Device.DoesNotExist:
+        return JsonResponse({"success": False, "error": "Device not found"}, status=404)
+    except Exception as e:
+        logger.exception("GenerateDraft failed")
+        return JsonResponse({"success": False, "error": str(e)}, status=500)
+
+
+@require_admin_role
+@require_http_methods(["POST"])
+def ApproveDraft(request):
+    """Turn an approved draft into a real Profile + DeviceTemplate and attach it."""
+    try:
+        draft = DraftDefinition.objects.get(pk=json.loads(request.body).get("draft_id"))
+        if draft.status != "pending":
+            return JsonResponse({"success": False, "error": f"Draft already {draft.status}"}, status=400)
+        if Profile.objects.filter(name=draft.proposed_name).exists():
+            return JsonResponse({"success": False, "error": "A profile with that name already exists"}, status=400)
+        # Check B (at approval): refuse if the device's IP became monitored since the draft was created.
+        if draft.device and _ip_already_monitored(draft.device.ip_address, exclude_device_id=draft.device.id):
+            return JsonResponse({"success": False, "error":
+                f"IP {draft.device.ip_address} is now monitored by another device — not attaching a "
+                f"duplicate. Reject this draft or remove the other device first."}, status=400)
+
+        profile = Profile.objects.create(
+            name=draft.proposed_name, description=f"[AI-authored] {draft.vendor}".strip(),
+            vendor=draft.vendor or "", product="", profile_data=draft.profile_json)
+
+        tpl_name = f"{draft.proposed_name}_template"
+        template = DeviceTemplate.objects.create(
+            name=tpl_name, vendor=draft.vendor or "Any", official=False,
+            matching_rules=[draft.vendor] if draft.vendor else [])
+        template.profiles.add(profile)
+
+        if draft.device:
+            draft.device.device_template = template
+            draft.device.save()
+
+        draft.status = "approved"
+        draft.reviewed_at = timezone.now()
+        draft.reviewed_by = getattr(request.user, "username", "")
+        draft.created_profile = profile
+        draft.created_template = template
+        draft.save()
+        return JsonResponse({"success": True, "message": "Approved - profile + template created and attached. "
+                                                         "Deploy from the SNMP page to start polling."})
+    except DraftDefinition.DoesNotExist:
+        return JsonResponse({"success": False, "error": "Draft not found"}, status=404)
+    except Exception as e:
+        logger.exception("ApproveDraft failed")
+        return JsonResponse({"success": False, "error": str(e)}, status=500)
+
+
+@require_admin_role
+@require_http_methods(["POST"])
+def RejectDraft(request):
+    try:
+        draft = DraftDefinition.objects.get(pk=json.loads(request.body).get("draft_id"))
+        draft.status = "rejected"
+        draft.reviewed_at = timezone.now()
+        draft.reviewed_by = getattr(request.user, "username", "")
+        draft.save()
+        return JsonResponse({"success": True, "message": "Draft rejected"})
+    except DraftDefinition.DoesNotExist:
+        return JsonResponse({"success": False, "error": "Draft not found"}, status=404)

--- a/src/logstashui/AI/views.py
+++ b/src/logstashui/AI/views.py
@@ -147,24 +147,34 @@ def ApproveDraft(request):
         draft = DraftDefinition.objects.get(pk=json.loads(request.body).get("draft_id"))
         if draft.status != "pending":
             return JsonResponse({"success": False, "error": f"Draft already {draft.status}"}, status=400)
-        if Profile.objects.filter(name=draft.proposed_name).exists():
-            return JsonResponse({"success": False, "error": "A profile with that name already exists"}, status=400)
+        # The proposed name is deterministic per device, so re-onboarding collides with the
+        # prior profile. Refresh an existing AI/user profile in place instead of dead-ending;
+        # only an OFFICIAL profile is protected from overwrite.
+        existing = Profile.objects.filter(name=draft.proposed_name).first()
+        if existing and existing.official_key:
+            return JsonResponse({"success": False, "error":
+                f"'{draft.proposed_name}' is an official profile and cannot be overwritten."}, status=400)
         # Check B (at approval): refuse if the device's IP became monitored since the draft was created.
         if draft.device and _ip_already_monitored(draft.device.ip_address, exclude_device_id=draft.device.id):
             return JsonResponse({"success": False, "error":
                 f"IP {draft.device.ip_address} is now monitored by another device — not attaching a "
                 f"duplicate. Reject this draft or remove the other device first."}, status=400)
 
-        profile = Profile.objects.create(
-            name=draft.proposed_name, description=f"[AI-authored] {draft.vendor}".strip(),
-            vendor=draft.vendor or "", product="", profile_data=draft.profile_json,
-            normalizers=draft.normalizers or [])
+        profile = existing or Profile(name=draft.proposed_name)
+        profile.description = f"[AI-authored] {draft.vendor}".strip()
+        profile.vendor = draft.vendor or ""
+        profile.product = ""
+        profile.profile_data = draft.profile_json
+        profile.normalizers = draft.normalizers or []
+        profile.save()
 
         tpl_name = f"{draft.proposed_name}_template"
-        template = DeviceTemplate.objects.create(
-            name=tpl_name, vendor=draft.vendor or "Any", official=False,
-            matching_rules=[draft.vendor] if draft.vendor else [])
-        template.profiles.add(profile)
+        template = DeviceTemplate.objects.filter(name=tpl_name, official=False).first()
+        if template is None:
+            template = DeviceTemplate.objects.create(
+                name=tpl_name, vendor=draft.vendor or "Any", official=False,
+                matching_rules=[draft.vendor] if draft.vendor else [])
+        template.profiles.set([profile])
 
         if draft.device:
             draft.device.device_template = template

--- a/src/logstashui/SNMP/data/authoring_instructions.md
+++ b/src/logstashui/SNMP/data/authoring_instructions.md
@@ -1,0 +1,65 @@
+You author SNMP **profiles** and **device templates** in LogstashUI 0.5.0 JSON format. The shipped repo profiles ARE the standard — mirror their conventions exactly. A profile maps SNMP OIDs to standardized dotted field names, grouped into `get` (scalar OIDs ending `.0`), `walk` (subtree OIDs), and `table` (per-row indexed OIDs), plus a top-level `normalizers` array that normalizes raw values **at the source**. Your output feeds the Logstash `snmp` input, so OID correctness is critical and the normalizer layer is mandatory wherever a raw unit differs from the target unit or a ratio should be derived.
+
+## Hard rules
+1. **Ground on the reference material provided INLINE below** — the `## REFERENCE PROFILES` and `## FIELD NAMING SCHEMA` sections contain the authoritative profiles and field dictionary for this request. Reuse OIDs, field names, table names, and normalizer blocks from them **verbatim** wherever they fit. Never re-derive something a reference profile already provides. Do NOT call any tools.
+2. **Never invent enterprise OIDs** (`1.3.6.1.4.1.<vendor>`). If an OID is not in the reference profiles and not from a standard MIB, DO NOT guess — list the metric under `"_unverified"` and tell the user to run `snmpwalk`. A wrong OID fails silently in production.
+3. **Standard MIBs are safe to use directly:** IF-MIB (1.3.6.1.2.1.2 / 1.3.6.1.2.1.31), SYSTEM group (1.3.6.1.2.1.1), HOST-RESOURCES-MIB (1.3.6.1.2.1.25), ENTITY / ENTITY-SENSOR-MIB (1.3.6.1.2.1.47 / 1.3.6.1.2.1.99), LLDP-MIB (1.0.8802.1.1.2).
+
+## Naming convention (the standard — match it exactly)
+- Field names are **semantic dotted names**, NEVER raw MIB object names. **A name containing ANY uppercase letter is INVALID** — it means you used a raw MIB object name. This applies EVEN to standard MIBs you know directly: translate every OID to its canonical schema name. Examples of required translation: `ifHCInOctets`→`traffic.in.bytes`; `entPhySensorValue`→`component.sensor.value`; `entPhySensorType`→`component.sensor.type`; `entPhySensorOperStatus`→`component.sensor.oper_status`; `entPhysicalName`→`component.name`. If unsure of the canonical name, consult the `## FIELD NAMING SCHEMA` provided below and copy the exact field name.
+- **Physical sensors / entities (ENTITY-SENSOR-MIB / ENTITY-MIB):** use table `component.sensor` with columns `type`,`scale`,`precision`,`value`,`oper_status`,`units_display`; and table `component` with column `name`. Never `entPhySensor`/`entPhysical`.
+- In a `table`, the **table name carries the group prefix** and the **column key is the leaf path**; they flatten with a dot to form the full field name:
+  - table `interface` + columns `status.admin`, `status.oper`, `traffic.in.bytes`, `traffic.out.errors` -> `interface.traffic.in.bytes`
+  - table `system.filesystem` + columns `total.bytes`, `used.bytes`, `mount_point` -> `system.filesystem.used.bytes`
+  - table `component.cpu` + column `load_pct` -> `component.cpu.load_pct`
+- `get` scalars use the full dotted path directly: `system.cpu.total.norm.pct`, `system.memory.actual.used.bytes`, `host.num_processes`, `system.memory.total.kb`.
+- Keep the unit in the name (`.bytes`, `.kb`, `.pct`, `.norm.pct`) and match the casing/style of the reference examples. Include an `index` column in tables where the standard examples do.
+
+## get vs walk vs table
+- Scalar single-instance value (CPU%, total memory) -> `get`, OID ends in `.0`.
+- Flat indexed subtree -> `walk`.
+- Per-row indexed data (interfaces, sensors, fans, PSUs, filesystems, CPUs) -> `table` with named `columns`.
+
+## Normalizers (normalize at the source — this is the differentiator)
+Emit a top-level `normalizers` array whenever a raw value is not already in the target unit, or a total/percentage should be derived. Reference fields by their **flattened** name (`<table>.<column>` for table scope; full dotted path for get scope). Two operations:
+
+- **multiply** — scales one field (has a target field). Unit conversion, e.g. raw centi-percent CPU -> fraction:
+```json
+{ "operation": "multiply",
+  "target": { "scope": "get", "field": "system.cpu.total.norm.pct" },
+  "params": { "multiply_value": 0.01 } }
+```
+  Table form: `"target": { "scope": "table", "table": "component.cpu", "field": "component.cpu.load_pct" }`.
+
+- **ratio** — derives totals/percentages from two fields (no target field). Any two of {used, free, total} suffice. Each output is opt-in; omit a key to skip it: `total_output_field` (v1+v2), `ratio1_output_field` (v1/(v1+v2)), `ratio2_output_field` (v2/(v1+v2)), `complement_ratio_output_field` ((v1-v2)/v1), `divide_output_field` (v2/v1).
+```json
+{ "operation": "ratio",
+  "target": { "scope": "get" },
+  "params": { "value1_field": "system.memory.actual.used.bytes",
+              "value2_field": "system.memory.actual.free.bytes",
+              "total_output_field": "system.memory.total.bytes",
+              "ratio1_output_field": "system.memory.actual.used.pct",
+              "ratio2_output_field": "system.memory.actual.free.pct" } }
+```
+  Table-scoped ratio: `"target": { "scope": "table", "table": "system.filesystem" }` with `value*_field` using flattened `table.column` paths.
+
+## Output — profile
+Return ONLY a single JSON object in this exact shape (top-level get/walk/table/normalizers — the import wraps get/walk/table into profile_data and carries normalizers through):
+```json
+{
+  "official_key": "<vendor>_<purpose>",
+  "name": "<vendor>_<purpose>",
+  "description": "<one line>",
+  "vendor": "<Vendor or Any>",
+  "product": "<product or Any>",
+  "model": "<model or Any>",
+  "get": {},
+  "walk": {},
+  "table": {},
+  "normalizers": []
+}
+```
+`official_key` is the globally-unique registry key (vendor-prefixed, matches the filename, e.g. `dell_idrac_cpu`); `name` is the display label and may be shorter (e.g. `idrac_cpu`) or equal to `official_key`. They are NOT required to match. If any metric is unverified, add a sibling `"_unverified": ["<metric>: reason"]` and state clearly that an snmpwalk is required before deploy. Do not include prose outside the JSON unless the user asked a question.
+
+## Output — device template
+`{ "official_key", "name", "type", "vendor", "product", "model", "profiles": [<profile names>], "matching_rules": [<sysDescr substrings>] }`. `type` is the device class (e.g. "Network", "Server", "Storage", "Printer", "Power"). Reuse existing profile names from the reference profiles in `profiles`. `matching_rules` must be real substrings of the device `sysDescr` (e.g. "Cisco IOS Software").

--- a/src/logstashui/SNMP/data/mib_reference/std_bgp4_mib.json
+++ b/src/logstashui/SNMP/data/mib_reference/std_bgp4_mib.json
@@ -1,0 +1,43 @@
+{
+  "name": "std_bgp4_mib",
+  "description": "BGP4-MIB (RFC 1269 / 4273) peer state and session metrics. bgpPeerState values: 1=idle, 2=connect, 3=active, 4=opensent, 5=openconfirm, 6=established. bgpPeerFsmEstablishedTransitions increments on session drops. Supported on Cisco IOS/NX-OS, Juniper Junos, Arista EOS, Nokia SR Linux, FRR.",
+  "vendor": "Any",
+  "product": "Any",
+  "model": "Any",
+  "get": {
+    "bgp.version": "1.3.6.1.2.1.15.1.0",
+    "bgp.local.as": "1.3.6.1.2.1.15.2.0",
+    "bgp.identifier": "1.3.6.1.2.1.15.4.0"
+  },
+  "walk": {},
+  "table": {
+    "bgpPeerTable": {
+      "columns": {
+        "bgpPeerIdentifier": "1.3.6.1.2.1.15.3.1.1",
+        "bgpPeerState": "1.3.6.1.2.1.15.3.1.2",
+        "bgpPeerAdminStatus": "1.3.6.1.2.1.15.3.1.3",
+        "bgpPeerNegotiatedVersion": "1.3.6.1.2.1.15.3.1.4",
+        "bgpPeerLocalAddr": "1.3.6.1.2.1.15.3.1.5",
+        "bgpPeerLocalPort": "1.3.6.1.2.1.15.3.1.6",
+        "bgpPeerRemoteAddr": "1.3.6.1.2.1.15.3.1.7",
+        "bgpPeerRemotePort": "1.3.6.1.2.1.15.3.1.8",
+        "bgpPeerRemoteAs": "1.3.6.1.2.1.15.3.1.9",
+        "bgpPeerInUpdates": "1.3.6.1.2.1.15.3.1.10",
+        "bgpPeerOutUpdates": "1.3.6.1.2.1.15.3.1.11",
+        "bgpPeerInTotalMsgs": "1.3.6.1.2.1.15.3.1.12",
+        "bgpPeerOutTotalMsgs": "1.3.6.1.2.1.15.3.1.13",
+        "bgpPeerLastError": "1.3.6.1.2.1.15.3.1.14",
+        "bgpPeerFsmEstablishedTransitions": "1.3.6.1.2.1.15.3.1.15",
+        "bgpPeerFsmEstablishedTime": "1.3.6.1.2.1.15.3.1.16",
+        "bgpPeerConnectRetryInterval": "1.3.6.1.2.1.15.3.1.17",
+        "bgpPeerHoldTime": "1.3.6.1.2.1.15.3.1.18",
+        "bgpPeerKeepAlive": "1.3.6.1.2.1.15.3.1.19",
+        "bgpPeerHoldTimeConfigured": "1.3.6.1.2.1.15.3.1.20",
+        "bgpPeerKeepAliveConfigured": "1.3.6.1.2.1.15.3.1.21",
+        "bgpPeerMinASOriginationInterval": "1.3.6.1.2.1.15.3.1.22",
+        "bgpPeerMinRouteAdvertisementInterval": "1.3.6.1.2.1.15.3.1.23",
+        "bgpPeerInUpdateElapsedTime": "1.3.6.1.2.1.15.3.1.24"
+      }
+    }
+  }
+}

--- a/src/logstashui/SNMP/data/mib_reference/std_entity_sensors.json
+++ b/src/logstashui/SNMP/data/mib_reference/std_entity_sensors.json
@@ -1,0 +1,28 @@
+{
+  "name": "std_entity_sensors",
+  "description": "ENTITY-SENSOR-MIB (RFC 3433) + ENTITY-MIB (RFC 4133) standard physical sensors: temperature, fan, voltage, current, power supply. Vendor-neutral health table used by Arista, Juniper, Cisco IOS-XR/NX-OS and others. Correlate entPhySensor* with entPhysical* by shared entPhysicalIndex.",
+  "vendor": "Any",
+  "product": "Any",
+  "model": "Any",
+  "get": {},
+  "walk": {},
+  "table": {
+    "entPhysical": {
+      "columns": {
+        "entPhysicalDescr": "1.3.6.1.2.1.47.1.1.1.1.2",
+        "entPhysicalClass": "1.3.6.1.2.1.47.1.1.1.1.5",
+        "entPhysicalName": "1.3.6.1.2.1.47.1.1.1.1.7"
+      }
+    },
+    "entPhySensor": {
+      "columns": {
+        "entPhySensorType": "1.3.6.1.2.1.99.1.1.1.1",
+        "entPhySensorScale": "1.3.6.1.2.1.99.1.1.1.2",
+        "entPhySensorPrecision": "1.3.6.1.2.1.99.1.1.1.3",
+        "entPhySensorValue": "1.3.6.1.2.1.99.1.1.1.4",
+        "entPhySensorOperStatus": "1.3.6.1.2.1.99.1.1.1.5",
+        "entPhySensorUnitsDisplay": "1.3.6.1.2.1.99.1.1.1.6"
+      }
+    }
+  }
+}

--- a/src/logstashui/SNMP/data/mib_reference/std_host_resources.json
+++ b/src/logstashui/SNMP/data/mib_reference/std_host_resources.json
@@ -1,0 +1,32 @@
+{
+  "name": "std_host_resources",
+  "description": "HOST-RESOURCES-MIB (RFC 2790) standard CPU load, memory and storage. Vendor-neutral; works on Linux/Windows hosts and many network OSes. hrStorage and hrProcessor are indexed tables.",
+  "vendor": "Any",
+  "product": "Any",
+  "model": "Any",
+  "get": {
+    "system.uptime": "1.3.6.1.2.1.25.1.1.0",
+    "system.users.count": "1.3.6.1.2.1.25.1.5.0",
+    "system.process.count": "1.3.6.1.2.1.25.1.6.0",
+    "system.memory.total.kbytes": "1.3.6.1.2.1.25.2.2.0"
+  },
+  "walk": {},
+  "table": {
+    "hrStorage": {
+      "columns": {
+        "hrStorageIndex": "1.3.6.1.2.1.25.2.3.1.1",
+        "hrStorageType": "1.3.6.1.2.1.25.2.3.1.2",
+        "hrStorageDescr": "1.3.6.1.2.1.25.2.3.1.3",
+        "hrStorageAllocationUnits": "1.3.6.1.2.1.25.2.3.1.4",
+        "hrStorageSize": "1.3.6.1.2.1.25.2.3.1.5",
+        "hrStorageUsed": "1.3.6.1.2.1.25.2.3.1.6"
+      }
+    },
+    "hrProcessor": {
+      "columns": {
+        "hrProcessorFrwID": "1.3.6.1.2.1.25.3.3.1.1",
+        "hrProcessorLoad": "1.3.6.1.2.1.25.3.3.1.2"
+      }
+    }
+  }
+}

--- a/src/logstashui/SNMP/data/mib_reference/std_ospf_mib.json
+++ b/src/logstashui/SNMP/data/mib_reference/std_ospf_mib.json
@@ -1,0 +1,55 @@
+{
+  "name": "std_ospf_mib",
+  "description": "OSPF-MIB (RFC 1850 / 4444) neighbor state, interface state, and area tables. ospfNbrState 8=Full (healthy), 1=Down. Supported on Cisco IOS/NX-OS, Juniper Junos, Arista EOS, Nokia SR Linux, FRR.",
+  "vendor": "Any",
+  "product": "Any",
+  "model": "Any",
+  "get": {
+    "ospf.router.id": "1.3.6.1.2.1.14.1.1.0",
+    "ospf.admin.status": "1.3.6.1.2.1.14.1.2.0",
+    "ospf.version.number": "1.3.6.1.2.1.14.1.3.0",
+    "ospf.area.border.router.status": "1.3.6.1.2.1.14.1.4.0",
+    "ospf.as.boundary.router.status": "1.3.6.1.2.1.14.1.7.0"
+  },
+  "walk": {},
+  "table": {
+    "ospfNbrTable": {
+      "columns": {
+        "ospfNbrIpAddr": "1.3.6.1.2.1.14.10.1.1",
+        "ospfNbrAddressLessIndex": "1.3.6.1.2.1.14.10.1.2",
+        "ospfNbrRtrId": "1.3.6.1.2.1.14.10.1.3",
+        "ospfNbrOptions": "1.3.6.1.2.1.14.10.1.4",
+        "ospfNbrPriority": "1.3.6.1.2.1.14.10.1.5",
+        "ospfNbrState": "1.3.6.1.2.1.14.10.1.6",
+        "ospfNbrEvents": "1.3.6.1.2.1.14.10.1.12",
+        "ospfNbrLsRetransQLen": "1.3.6.1.2.1.14.10.1.13",
+        "ospfNbmaNbrPermanence": "1.3.6.1.2.1.14.10.1.14",
+        "ospfNbrHelloSuppressed": "1.3.6.1.2.1.14.10.1.15"
+      }
+    },
+    "ospfIfTable": {
+      "columns": {
+        "ospfIfIpAddress": "1.3.6.1.2.1.14.7.1.1",
+        "ospfAddressLessIf": "1.3.6.1.2.1.14.7.1.2",
+        "ospfIfAdminStat": "1.3.6.1.2.1.14.7.1.5",
+        "ospfIfAreaId": "1.3.6.1.2.1.14.7.1.6",
+        "ospfIfType": "1.3.6.1.2.1.14.7.1.7",
+        "ospfIfState": "1.3.6.1.2.1.14.7.1.12",
+        "ospfIfDesignatedRouter": "1.3.6.1.2.1.14.7.1.13",
+        "ospfIfRetransInterval": "1.3.6.1.2.1.14.7.1.4"
+      }
+    },
+    "ospfAreaTable": {
+      "columns": {
+        "ospfAreaId": "1.3.6.1.2.1.14.2.1.1",
+        "ospfAuthType": "1.3.6.1.2.1.14.2.1.3",
+        "ospfImportAsExtern": "1.3.6.1.2.1.14.2.1.4",
+        "ospfSpfRuns": "1.3.6.1.2.1.14.2.1.5",
+        "ospfAreaBdrRtrCount": "1.3.6.1.2.1.14.2.1.6",
+        "ospfAsBdrRtrCount": "1.3.6.1.2.1.14.2.1.7",
+        "ospfAreaLsaCount": "1.3.6.1.2.1.14.2.1.8",
+        "ospfAreaStatus": "1.3.6.1.2.1.14.2.1.12"
+      }
+    }
+  }
+}

--- a/src/logstashui/SNMP/data/mib_reference/std_ucd_linux.json
+++ b/src/logstashui/SNMP/data/mib_reference/std_ucd_linux.json
@@ -1,0 +1,27 @@
+{
+  "name": "std_ucd_linux",
+  "description": "UCD-SNMP-MIB (net-snmp, enterprise 2021) standard Linux/Unix host metrics: CPU percentages, load averages, real and swap memory. Ubiquitous on Linux hosts running net-snmp/snmpd. All scalars (.0). laLoad 1/5/15-minute load averages are an indexed table (laIndex 1,2,3).",
+  "vendor": "Any",
+  "product": "net-snmp",
+  "model": "Any",
+  "get": {
+    "system.cpu.user.pct": "1.3.6.1.4.1.2021.11.9.0",
+    "system.cpu.system.pct": "1.3.6.1.4.1.2021.11.10.0",
+    "system.cpu.idle.pct": "1.3.6.1.4.1.2021.11.11.0",
+    "system.memory.total.real.kbytes": "1.3.6.1.4.1.2021.4.5.0",
+    "system.memory.available.real.kbytes": "1.3.6.1.4.1.2021.4.6.0",
+    "system.memory.total.swap.kbytes": "1.3.6.1.4.1.2021.4.3.0",
+    "system.memory.available.swap.kbytes": "1.3.6.1.4.1.2021.4.4.0",
+    "system.memory.buffer.kbytes": "1.3.6.1.4.1.2021.4.14.0",
+    "system.memory.cached.kbytes": "1.3.6.1.4.1.2021.4.15.0"
+  },
+  "walk": {},
+  "table": {
+    "laLoad": {
+      "columns": {
+        "laNames": "1.3.6.1.4.1.2021.10.1.2",
+        "laLoad": "1.3.6.1.4.1.2021.10.1.3"
+      }
+    }
+  }
+}

--- a/src/logstashui/SNMP/data/schema_reference/snmp_field_schema.md
+++ b/src/logstashui/SNMP/data/schema_reference/snmp_field_schema.md
@@ -1,0 +1,577 @@
+# SNMP Field Reference
+
+Organized by data domain. Use this to find the canonical field name, source MIB, and OID before adding new fields so your data stays consistent with existing schema.
+
+GET scalar fields have no table prefix. Table fields are written as `<table>.<field>`.
+
+---
+
+- [System Identity](#system-identity)
+- [System Metrics](#system-metrics)
+- [Network Interfaces](#network-interfaces)
+- [RMON (Interface Error Statistics)](#rmon-interface-error-statistics)
+- [IP & Addressing](#ip--addressing)
+- [ARP](#arp)
+- [Network Discovery — LLDP](#network-discovery--lldp)
+- [Network Discovery — CDP](#network-discovery--cdp)
+- [Layer 2 — MAC Table](#layer-2--mac-table)
+- [Routing — BGP](#routing--bgp)
+- [Routing — OSPF](#routing--ospf)
+- [Physical Sensors](#physical-sensors)
+- [Server Hardware — CPU](#server-hardware--cpu)
+- [Server Hardware — Memory](#server-hardware--memory)
+- [Server Hardware — Fans](#server-hardware--fans)
+- [Server Hardware — Power Supply](#server-hardware--power-supply)
+- [Server Hardware — RAID Controller](#server-hardware--raid-controller)
+- [UPS / Power](#ups--power)
+- [Storage Volumes](#storage-volumes)
+- [Fibre Channel — Ports](#fibre-channel--ports)
+- [Fibre Channel — Name Server](#fibre-channel--name-server)
+- [Printers](#printers)
+
+---
+
+## System Identity
+
+Standard device identity fields present on virtually all SNMP-capable devices. Source: **SNMPv2-MIB**.
+
+| Field | OID | MIB | Description |
+|---|---|---|---|
+| `observer.sys_descr` | `1.3.6.1.2.1.1.1.0` | SNMPv2-MIB | Full hardware/software description string |
+| `observer.object_id` | `1.3.6.1.2.1.1.2.0` | SNMPv2-MIB | Vendor-assigned OID identifying device type |
+| `host.name` | `1.3.6.1.2.1.1.5.0` | SNMPv2-MIB | Configured hostname |
+| `host.uptime` | `1.3.6.1.2.1.1.3.0` | SNMPv2-MIB | Time since last reboot (hundredths of a second) |
+| `host.location` | `1.3.6.1.2.1.1.6.0` | SNMPv2-MIB | Configured physical location string |
+| `host.contact` | `1.3.6.1.2.1.1.4.0` | SNMPv2-MIB | Configured admin contact string |
+
+Device-specific identity fields shared across vendor profiles (OIDs vary per vendor):
+
+| Field | Description |
+|---|---|
+| `observer.model` | Device model name |
+| `observer.serial_number` | Hardware serial number |
+| `observer.firmware_version` | Active firmware/software version |
+| `observer.mac_address` | Chassis/management MAC address |
+| `observer.chipset` | Chipset identifier |
+| `observer.product_id` | Vendor product ID |
+| `observer.system_status` | Device-reported overall system readiness state |
+
+---
+
+## System Metrics
+
+CPU, memory, and load fields. Standard source is **UCD-SNMP-MIB** (Net-SNMP, Linux/BSD). Vendor devices expose equivalent fields under their own enterprise OIDs.
+
+| Field | OID | MIB | Description |
+|---|---|---|---|
+| `system.cpu.total.norm.pct` | `1.3.6.1.4.1.2021.11.*` | UCD-SNMP-MIB | Normalized CPU utilization (0–1). Derived from raw counters or vendor scalar — divide raw vendor percentages by 100 |
+| `system.cpu.raw.user` | `1.3.6.1.4.1.2021.11.50.0` | UCD-SNMP-MIB | Raw CPU ticks spent in user mode |
+| `system.cpu.raw.nice` | `1.3.6.1.4.1.2021.11.51.0` | UCD-SNMP-MIB | Raw CPU ticks spent in nice (low-priority user) mode |
+| `system.cpu.raw.system` | `1.3.6.1.4.1.2021.11.52.0` | UCD-SNMP-MIB | Raw CPU ticks spent in kernel/system mode |
+| `system.cpu.raw.idle` | `1.3.6.1.4.1.2021.11.53.0` | UCD-SNMP-MIB | Raw CPU ticks spent idle |
+| `system.cpu.raw.wait` | `1.3.6.1.4.1.2021.11.54.0` | UCD-SNMP-MIB | Raw CPU ticks spent waiting on I/O |
+| `system.cpu.raw.kernel` | `1.3.6.1.4.1.2021.11.55.0` | UCD-SNMP-MIB | Raw CPU ticks spent in kernel interrupt context |
+| `system.cpu.raw.interrupt` | `1.3.6.1.4.1.2021.11.56.0` | UCD-SNMP-MIB | Raw CPU ticks spent handling hardware interrupts |
+| `system.cpu.num_cpus` | `1.3.6.1.4.1.2021.11.67.0` | UCD-SNMP-MIB | Number of CPU cores |
+| `system.load.1` | `1.3.6.1.4.1.2021.10.1.3.1` | UCD-SNMP-MIB | 1-minute load average |
+| `system.load.5` | `1.3.6.1.4.1.2021.10.1.3.2` | UCD-SNMP-MIB | 5-minute load average |
+| `system.load.15` | `1.3.6.1.4.1.2021.10.1.3.3` | UCD-SNMP-MIB | 15-minute load average |
+| `system.memory.actual.total.kb` | `1.3.6.1.4.1.2021.4.5.0` | UCD-SNMP-MIB | Total physical RAM in KB |
+| `system.memory.actual.available.kb` | `1.3.6.1.4.1.2021.4.6.0` | UCD-SNMP-MIB | Available (free + reclaimable) RAM in KB |
+| `system.memory.actual.free.kb` | `1.3.6.1.4.1.2021.4.11.0` | UCD-SNMP-MIB | Truly free (unallocated) RAM in KB |
+| `system.memory.actual.cached.kb` | `1.3.6.1.4.1.2021.4.15.0` | UCD-SNMP-MIB | RAM used for disk cache in KB |
+| `system.memory.actual.total.bytes` | vendor | — | Total RAM in bytes (vendor devices) |
+| `system.memory.actual.used.bytes` | vendor | — | Used RAM in bytes (vendor devices) |
+| `system.memory.actual.free.bytes` | vendor | — | Free RAM in bytes (vendor devices) |
+| `system.memory.actual.used.pct` | derived | — | Memory utilization (0–1). Always derived via normalizer |
+| `system.memory.actual.free.pct` | derived | — | Memory free ratio (0–1). Always derived via normalizer |
+| `system.memory.total` | derived | — | Total memory computed from used + free when no direct OID exists |
+
+---
+
+## Network Interfaces
+
+Per-interface counters and state. Table: `interface`. Source: **IF-MIB** (`ifTable` and `ifXTable`).
+
+| Field | OID | MIB | Description |
+|---|---|---|---|
+| `interface.index` | `1.3.6.1.2.1.2.2.1.1` | IF-MIB | Interface index (ifIndex) |
+| `interface.name` | `1.3.6.1.2.1.2.2.1.2` | IF-MIB | Interface description string (ifDescr) |
+| `interface.alt_name` | `1.3.6.1.2.1.31.1.1.1.1` | IF-MIB | Shorter interface name (ifName from ifXTable) |
+| `interface.alias` | `1.3.6.1.2.1.31.1.1.1.18` | IF-MIB | Operator-configured alias (ifAlias) |
+| `interface.type` | `1.3.6.1.2.1.2.2.1.3` | IF-MIB | Interface type enum (ethernetCsmacd, etc.) |
+| `interface.status.admin` | `1.3.6.1.2.1.2.2.1.7` | IF-MIB | Admin state: 1=up, 2=down, 3=testing |
+| `interface.status.oper` | `1.3.6.1.2.1.2.2.1.8` | IF-MIB | Operational state: 1=up, 2=down |
+| `interface.speed` | `1.3.6.1.2.1.2.2.1.5` | IF-MIB | Interface speed in bps (ifSpeed, 32-bit) |
+| `interface.speed_high_mbps` | `1.3.6.1.2.1.31.1.1.1.15` | IF-MIB | Interface speed in Mbps (ifHighSpeed, 64-bit) |
+| `interface.mac` | `1.3.6.1.2.1.2.2.1.6` | IF-MIB | Interface MAC address |
+| `interface.mtu` | `1.3.6.1.2.1.2.2.1.4` | IF-MIB | MTU in bytes |
+| `interface.last_change` | `1.3.6.1.2.1.2.2.1.9` | IF-MIB | Uptime timestamp of last state change |
+| `interface.vlan_id` | `1.3.6.1.2.1.17.7.1.4.5.1.1` | Q-BRIDGE-MIB | VLAN ID assigned to interface |
+| `interface.traffic.in.bytes` | `1.3.6.1.2.1.31.1.1.1.6` | IF-MIB | Inbound octets (64-bit counter) |
+| `interface.traffic.out.bytes` | `1.3.6.1.2.1.31.1.1.1.10` | IF-MIB | Outbound octets (64-bit counter) |
+| `interface.traffic.in.unicast_packets` | `1.3.6.1.2.1.31.1.1.1.7` | IF-MIB | Inbound unicast packets |
+| `interface.traffic.out.unicast_packets` | `1.3.6.1.2.1.31.1.1.1.11` | IF-MIB | Outbound unicast packets |
+| `interface.traffic.in.multicast_packets` | `1.3.6.1.2.1.31.1.1.1.8` | IF-MIB | Inbound multicast packets |
+| `interface.traffic.out.multicast_packets` | `1.3.6.1.2.1.31.1.1.1.12` | IF-MIB | Outbound multicast packets |
+| `interface.traffic.in.broadcast_packets` | `1.3.6.1.2.1.31.1.1.1.9` | IF-MIB | Inbound broadcast packets |
+| `interface.traffic.out.broadcast_packets` | `1.3.6.1.2.1.31.1.1.1.13` | IF-MIB | Outbound broadcast packets |
+| `interface.traffic.in.errors` | `1.3.6.1.2.1.2.2.1.14` | IF-MIB | Inbound packets with errors |
+| `interface.traffic.out.errors` | `1.3.6.1.2.1.2.2.1.20` | IF-MIB | Outbound packets with errors |
+| `interface.traffic.in.discards` | `1.3.6.1.2.1.2.2.1.13` | IF-MIB | Inbound packets dropped (no buffer) |
+| `interface.traffic.out.discards` | `1.3.6.1.2.1.2.2.1.19` | IF-MIB | Outbound packets dropped (no buffer) |
+
+---
+
+## RMON (Interface Error Statistics)
+
+Extended per-port Ethernet stats. Table: `interface` (RMON). Supplements IF-MIB with detailed error breakdowns and packet-size histograms. Source: **RMON-MIB**.
+
+| Field | OID | MIB | Description |
+|---|---|---|---|
+| `interface.data_source` | `1.3.6.1.2.1.16.1.1.1.2` | RMON-MIB | OID pointer to the monitored interface |
+| `interface.traffic.total.bytes` | `1.3.6.1.2.1.16.1.1.1.4` | RMON-MIB | Total octets received (including errors) |
+| `interface.traffic.total.packets` | `1.3.6.1.2.1.16.1.1.1.5` | RMON-MIB | Total frames received |
+| `interface.traffic.total.broadcast_packets` | `1.3.6.1.2.1.16.1.1.1.6` | RMON-MIB | Good broadcast frames received |
+| `interface.traffic.total.multicast_packets` | `1.3.6.1.2.1.16.1.1.1.7` | RMON-MIB | Good multicast frames received |
+| `interface.traffic.total.drop_events` | `1.3.6.1.2.1.16.1.1.1.3` | RMON-MIB | Events where packets were dropped due to lack of resources |
+| `interface.traffic.total.errors_crc_align` | `1.3.6.1.2.1.16.1.1.1.8` | RMON-MIB | Frames with bad CRC or alignment errors |
+| `interface.traffic.total.errors_undersize` | `1.3.6.1.2.1.16.1.1.1.9` | RMON-MIB | Frames shorter than 64 bytes with valid CRC |
+| `interface.traffic.total.errors_oversize` | `1.3.6.1.2.1.16.1.1.1.10` | RMON-MIB | Frames longer than 1518 bytes with valid CRC |
+| `interface.traffic.total.errors_fragments` | `1.3.6.1.2.1.16.1.1.1.11` | RMON-MIB | Frames shorter than 64 bytes with invalid CRC |
+| `interface.traffic.total.errors_jabbers` | `1.3.6.1.2.1.16.1.1.1.12` | RMON-MIB | Frames longer than 1518 bytes with invalid CRC |
+| `interface.traffic.total.errors_collisions` | `1.3.6.1.2.1.16.1.1.1.13` | RMON-MIB | Collision events detected |
+| `interface.traffic.total.pkts_64` | `1.3.6.1.2.1.16.1.1.1.14` | RMON-MIB | Frames of exactly 64 bytes |
+| `interface.traffic.total.pkts_65_127` | `1.3.6.1.2.1.16.1.1.1.15` | RMON-MIB | Frames 65–127 bytes |
+| `interface.traffic.total.pkts_128_255` | `1.3.6.1.2.1.16.1.1.1.16` | RMON-MIB | Frames 128–255 bytes |
+| `interface.traffic.total.pkts_256_511` | `1.3.6.1.2.1.16.1.1.1.17` | RMON-MIB | Frames 256–511 bytes |
+| `interface.traffic.total.pkts_512_1023` | `1.3.6.1.2.1.16.1.1.1.18` | RMON-MIB | Frames 512–1023 bytes |
+| `interface.traffic.total.pkts_1024_1518` | `1.3.6.1.2.1.16.1.1.1.19` | RMON-MIB | Frames 1024–1518 bytes |
+
+---
+
+## IP & Addressing
+
+IP address table. Table: `ip_addr`. Source: **IP-MIB**.
+
+| Field | OID | MIB | Description |
+|---|---|---|---|
+| `ip_addr.address` | `1.3.6.1.2.1.4.20.1.1` | IP-MIB | IP address assigned to this entry |
+| `ip_addr.if_index` | `1.3.6.1.2.1.4.20.1.2` | IP-MIB | ifIndex of the interface this address is bound to |
+| `ip_addr.netmask` | `1.3.6.1.2.1.4.20.1.3` | IP-MIB | Subnet mask for this address |
+
+---
+
+## ARP
+
+ARP forwarding table. Table: `arp`. Source: **IP-MIB**. Can produce high data volumes on large networks.
+
+| Field | OID | MIB | Description |
+|---|---|---|---|
+| `arp.interface_index` | `1.3.6.1.2.1.4.22.1.1` | IP-MIB | ifIndex of the interface this ARP entry was learned on |
+| `arp.mac_addr` | `1.3.6.1.2.1.4.22.1.2` | IP-MIB | MAC address of the remote host |
+| `arp.ip_addr` | `1.3.6.1.2.1.4.22.1.3` | IP-MIB | IP address of the remote host |
+
+---
+
+## Network Discovery — LLDP
+
+LLDP local device info and neighbor table. Source: **LLDP-MIB** (IEEE 802.1AB).
+
+**GET scalars:**
+
+| Field | OID | MIB | Description |
+|---|---|---|---|
+| `network.local.chassis_id_subtype` | `1.0.8802.1.1.2.1.3.1.0` | LLDP-MIB | Encoding type of the local chassis ID |
+| `network.local.chassis_id` | `1.0.8802.1.1.2.1.3.2.0` | LLDP-MIB | Local chassis identifier |
+| `network.local.capabilities_supported` | `1.0.8802.1.1.2.1.3.5.0` | LLDP-MIB | Bitmask of capabilities this device supports |
+| `network.local.capabilities_enabled` | `1.0.8802.1.1.2.1.3.6.0` | LLDP-MIB | Bitmask of capabilities currently enabled |
+| `network.discovery.last_change` | `1.0.8802.1.1.2.1.2.1.0` | LLDP-MIB | Uptime when the neighbor table last changed |
+| `network.discovery.inserts` | `1.0.8802.1.1.2.1.2.2.0` | LLDP-MIB | Number of entries added to the neighbor table |
+| `network.discovery.deletes` | `1.0.8802.1.1.2.1.2.3.0` | LLDP-MIB | Number of entries deleted from the neighbor table |
+| `network.discovery.drops` | `1.0.8802.1.1.2.1.2.4.0` | LLDP-MIB | Neighbor entries dropped due to resource limits |
+| `network.discovery.ageouts` | `1.0.8802.1.1.2.1.2.5.0` | LLDP-MIB | Neighbor entries that expired via TTL |
+
+**Table: `network.local_port`** — one row per local port advertising LLDP:
+
+| Field | OID | MIB | Description |
+|---|---|---|---|
+| `network.local_port.index` | `1.0.8802.1.1.2.1.3.7.1.1` | LLDP-MIB | Local port index |
+| `network.local_port.id_subtype` | `1.0.8802.1.1.2.1.3.7.1.2` | LLDP-MIB | Encoding type of the port ID |
+| `network.local_port.id` | `1.0.8802.1.1.2.1.3.7.1.3` | LLDP-MIB | Port identifier value |
+| `network.local_port.description` | `1.0.8802.1.1.2.1.3.7.1.4` | LLDP-MIB | Port description string |
+
+**Table: `network.neighbor`** — one row per discovered neighbor:
+
+| Field | OID | MIB | Description |
+|---|---|---|---|
+| `network.neighbor.local_interface.index` | `1.0.8802.1.1.2.1.4.1.1.2` | LLDP-MIB | Local ifIndex where this neighbor was seen |
+| `network.neighbor.index` | `1.0.8802.1.1.2.1.4.1.1.3` | LLDP-MIB | Neighbor table entry index |
+| `network.neighbor.chassis_id_subtype` | `1.0.8802.1.1.2.1.4.1.1.4` | LLDP-MIB | Encoding type of neighbor's chassis ID |
+| `network.neighbor.chassis_id` | `1.0.8802.1.1.2.1.4.1.1.5` | LLDP-MIB | Neighbor chassis identifier |
+| `network.neighbor.port_id_subtype` | `1.0.8802.1.1.2.1.4.1.1.6` | LLDP-MIB | Encoding type of neighbor's port ID |
+| `network.neighbor.port` | `1.0.8802.1.1.2.1.4.1.1.7` | LLDP-MIB | Neighbor port identifier |
+| `network.neighbor.port_description` | `1.0.8802.1.1.2.1.4.1.1.8` | LLDP-MIB | Neighbor port description |
+| `network.neighbor.device_id` | `1.0.8802.1.1.2.1.4.1.1.9` | LLDP-MIB | Neighbor system name (device ID) |
+| `network.neighbor.platform` | `1.0.8802.1.1.2.1.4.1.1.10` | LLDP-MIB | Neighbor system description |
+| `network.neighbor.capabilities_supported` | `1.0.8802.1.1.2.1.4.1.1.11` | LLDP-MIB | Bitmask of capabilities the neighbor supports |
+| `network.neighbor.capabilities` | `1.0.8802.1.1.2.1.4.1.1.12` | LLDP-MIB | Bitmask of capabilities the neighbor has enabled |
+
+**Table: `network.neighbor_address`** — management addresses for neighbors:
+
+| Field | OID | MIB | Description |
+|---|---|---|---|
+| `network.neighbor_address.addr_subtype` | `1.0.8802.1.1.2.1.4.2.1.1` | LLDP-MIB | Address type (IPv4, IPv6, etc.) |
+| `network.neighbor_address.address` | `1.0.8802.1.1.2.1.4.2.1.2` | LLDP-MIB | Management IP address of the neighbor |
+| `network.neighbor_address.if_subtype` | `1.0.8802.1.1.2.1.4.2.1.3` | LLDP-MIB | Interface numbering subtype |
+| `network.neighbor_address.if_id` | `1.0.8802.1.1.2.1.4.2.1.4` | LLDP-MIB | Interface number the management address is reachable via |
+| `network.neighbor_address.object_id` | `1.0.8802.1.1.2.1.4.2.1.5` | LLDP-MIB | OID of the neighbor's management object |
+
+---
+
+## Network Discovery — CDP
+
+Cisco Discovery Protocol. Cisco-proprietary equivalent of LLDP. Source: **CISCO-CDP-MIB**.
+
+**GET scalars:**
+
+| Field | OID | MIB | Description |
+|---|---|---|---|
+| `network.discovery.cdp_enabled` | `1.3.6.1.4.1.9.9.23.1.3.1` | CISCO-CDP-MIB | Whether CDP is globally enabled on the device |
+| `network.discovery.last_change` | `1.3.6.1.4.1.9.9.23.1.3.5` | CISCO-CDP-MIB | Uptime when the neighbor table last changed |
+
+**Table: `network.neighbor`:**
+
+| Field | OID | MIB | Description |
+|---|---|---|---|
+| `network.neighbor.local_interface.index` | `1.3.6.1.4.1.9.9.23.1.2.1.1.1` | CISCO-CDP-MIB | Local ifIndex where this neighbor was seen |
+| `network.neighbor.address` | `1.3.6.1.4.1.9.9.23.1.2.1.1.4` | CISCO-CDP-MIB | Neighbor management IP address |
+| `network.neighbor.version` | `1.3.6.1.4.1.9.9.23.1.2.1.1.5` | CISCO-CDP-MIB | Neighbor IOS / software version string |
+| `network.neighbor.device_id` | `1.3.6.1.4.1.9.9.23.1.2.1.1.6` | CISCO-CDP-MIB | Neighbor device ID (usually hostname) |
+| `network.neighbor.port` | `1.3.6.1.4.1.9.9.23.1.2.1.1.7` | CISCO-CDP-MIB | Neighbor port the connection is on |
+| `network.neighbor.platform` | `1.3.6.1.4.1.9.9.23.1.2.1.1.8` | CISCO-CDP-MIB | Neighbor hardware platform string |
+| `network.neighbor.capabilities` | `1.3.6.1.4.1.9.9.23.1.2.1.1.9` | CISCO-CDP-MIB | Bitmask of neighbor capabilities |
+
+---
+
+## Layer 2 — MAC Table
+
+Forwarding database (FDB). Table: `mac_table`. Source: **BRIDGE-MIB** (RFC 1493). Can produce high data volumes on large networks.
+
+| Field | OID | MIB | Description |
+|---|---|---|---|
+| `mac_table.mac_addr` | `1.3.6.1.2.1.17.4.3.1.1` | BRIDGE-MIB | Learned MAC address |
+| `mac_table.port_index` | `1.3.6.1.2.1.17.4.3.1.2` | BRIDGE-MIB | Bridge port number this MAC was learned on |
+| `mac_table.status` | `1.3.6.1.2.1.17.4.3.1.3` | BRIDGE-MIB | Entry status: 1=learned, 2=invalid, 3=self, 4=mgmt |
+
+---
+
+## Routing — BGP
+
+BGP peer session state and update counters. Source: **BGP4-MIB** (RFC 1657).
+
+**GET scalar:**
+
+| Field | OID | MIB | Description |
+|---|---|---|---|
+| `bgp_peer.local_asn` | `1.3.6.1.2.1.15.2` | BGP4-MIB | Local autonomous system number |
+
+**Table: `bgp_peer`:**
+
+| Field | OID | MIB | Description |
+|---|---|---|---|
+| `bgp_peer.peer_state` | `1.3.6.1.2.1.15.3.1.2` | BGP4-MIB | Session state: 1=idle … 6=established |
+| `bgp_peer.remote_ip` | `1.3.6.1.2.1.15.3.1.7` | BGP4-MIB | Remote peer IP address |
+| `bgp_peer.remote_asn` | `1.3.6.1.2.1.15.3.1.9` | BGP4-MIB | Remote peer autonomous system number |
+| `bgp_peer.in_updates` | `1.3.6.1.2.1.15.3.1.10` | BGP4-MIB | UPDATE messages received from this peer |
+| `bgp_peer.out_updates` | `1.3.6.1.2.1.15.3.1.11` | BGP4-MIB | UPDATE messages sent to this peer |
+| `bgp_peer.uptime_seconds` | `1.3.6.1.2.1.15.3.1.16` | BGP4-MIB | Time this session has been in Established state |
+
+---
+
+## Routing — OSPF
+
+OSPF neighbor adjacency table. Table: `ospf_neighbor`. Source: **OSPF-MIB** (RFC 1850).
+
+| Field | OID | MIB | Description |
+|---|---|---|---|
+| `ospf_neighbor.neighbor_ip` | `1.3.6.1.2.1.14.10.1.1` | OSPF-MIB | IP address of the OSPF neighbor |
+| `ospf_neighbor.router_id` | `1.3.6.1.2.1.14.10.1.3` | OSPF-MIB | Router ID of the OSPF neighbor |
+| `ospf_neighbor.priority` | `1.3.6.1.2.1.14.10.1.5` | OSPF-MIB | Neighbor DR election priority |
+| `ospf_neighbor.state` | `1.3.6.1.2.1.14.10.1.6` | OSPF-MIB | Adjacency state: 1=down … 8=full |
+| `ospf_neighbor.retrans_count` | `1.3.6.1.2.1.14.10.1.7` | OSPF-MIB | Number of LSAs waiting to be acknowledged |
+
+---
+
+## Physical Sensors
+
+Generic physical sensor readings (temperature, fan speed, voltage, current, power). Tables: `component.sensor` and `component`. Source: **ENTITY-SENSOR-MIB** (RFC 3433) + **ENTITY-MIB** (RFC 2737).
+
+| Field | OID | MIB | Description |
+|---|---|---|---|
+| `component.sensor.type` | `1.3.6.1.2.1.99.1.1.1.1` | ENTITY-SENSOR-MIB | Sensor type enum: 1=other, 3=voltsAC, 5=amperes, 8=celsius, 10=rpm, 12=watts |
+| `component.sensor.scale` | `1.3.6.1.2.1.99.1.1.1.2` | ENTITY-SENSOR-MIB | Power-of-10 scale factor to apply to `value` |
+| `component.sensor.precision` | `1.3.6.1.2.1.99.1.1.1.3` | ENTITY-SENSOR-MIB | Number of decimal digits of precision |
+| `component.sensor.value` | `1.3.6.1.2.1.99.1.1.1.4` | ENTITY-SENSOR-MIB | Raw sensor reading (apply `scale` and `precision` to get true value) |
+| `component.sensor.oper_status` | `1.3.6.1.2.1.99.1.1.1.5` | ENTITY-SENSOR-MIB | Sensor validity: 1=ok, 2=unavailable, 3=nonoperational |
+| `component.sensor.units_display` | `1.3.6.1.2.1.99.1.1.1.6` | ENTITY-SENSOR-MIB | Human-readable units string (e.g. "Celsius", "RPM") |
+| `component.name` | `1.3.6.1.2.1.47.1.1.1.1.7` | ENTITY-MIB | Human-readable name for the physical component (joined by entPhysicalIndex) |
+
+---
+
+## Server Hardware — CPU
+
+CPU status per socket. Table: `component.cpu`.
+
+| Field | OID | MIB | Description |
+|---|---|---|---|
+| `system.status` | `1.3.6.1.4.1.674.10892.5.2.1.0` | iDRAC-MIB | Overall chassis health rollup (GET scalar) |
+| `component.cpu.id` | `1.3.6.1.4.1.674.10892.5.4.1100.30.1.2` | iDRAC-MIB | Processor index within chassis |
+| `component.cpu.chassis_id` | `1.3.6.1.4.1.674.10892.5.4.1100.30.1.1` | iDRAC-MIB | Chassis containing this processor |
+| `component.cpu.status` | `1.3.6.1.4.1.674.10892.5.4.1100.30.1.5` | iDRAC-MIB | Processor state: 1=other, 2=unknown, 3=ok, 4=nonCritical, 5=critical, 6=nonRecoverable |
+
+---
+
+## Server Hardware — Memory
+
+DIMM slot state and capacity. Table: `component.memory`.
+
+| Field | OID | MIB | Description |
+|---|---|---|---|
+| `component.memory.index` | `1.3.6.1.4.1.674.10892.5.4.1100.50.1.1` | iDRAC-MIB | DIMM slot index |
+| `component.memory.location` | `1.3.6.1.4.1.674.10892.5.4.1100.50.1.5` | iDRAC-MIB | Physical slot label (e.g. "DIMM.Socket.A1") |
+| `component.memory.state` | `1.3.6.1.4.1.674.10892.5.4.1100.50.1.4` | iDRAC-MIB | DIMM state enum (ok, degraded, failed, etc.) |
+| `component.memory.size.mb` | `1.3.6.1.4.1.674.10892.5.4.1100.50.1.14` | iDRAC-MIB | DIMM capacity in MB |
+
+---
+
+## Server Hardware — Fans
+
+Fan speed and state. Table: `component.fan`. OIDs shown are iDRAC; Cisco uses CISCO-ENVMON-MIB for state-only entries.
+
+| Field | OID | MIB | Description |
+|---|---|---|---|
+| `component.fan.index` | `1.3.6.1.4.1.674.10892.5.4.700.12.1.1` | iDRAC-MIB | Fan slot index |
+| `component.fan.description` | `1.3.6.1.4.1.674.10892.5.4.700.12.1.7` | iDRAC-MIB | Fan slot label |
+| `component.fan.state` | `1.3.6.1.4.1.674.10892.5.4.700.12.1.5` | iDRAC-MIB | Fan state enum (ok, degraded, failed, etc.) |
+| `component.fan.rpm` | `1.3.6.1.4.1.674.10892.5.4.700.12.1.6` | iDRAC-MIB | Current fan speed in RPM |
+
+Cisco equivalent (state only, no RPM):
+
+| Field | OID | MIB | Description |
+|---|---|---|---|
+| `component.fan.description` | `1.3.6.1.4.1.9.9.13.1.4.1.2` | CISCO-ENVMON-MIB | Fan tray label |
+| `component.fan.state` | `1.3.6.1.4.1.9.9.13.1.4.1.3` | CISCO-ENVMON-MIB | Fan state: 1=normal, 2=warning, 3=critical, 4=shutdown, 5=notPresent |
+
+---
+
+## Server Hardware — Power Supply
+
+Power supply slot state. Table: `component.power_supply`.
+
+| Field | OID | MIB | Description |
+|---|---|---|---|
+| `component.power_supply.index` | `1.3.6.1.4.1.674.10892.5.4.600.12.1.1` | iDRAC-MIB | PSU slot index |
+| `component.power_supply.location` | `1.3.6.1.4.1.674.10892.5.4.600.12.1.7` | iDRAC-MIB | PSU slot label |
+| `component.power_supply.state` | `1.3.6.1.4.1.674.10892.5.4.600.12.1.5` | iDRAC-MIB | PSU state enum (ok, degraded, failed, absent, etc.) |
+
+---
+
+## Server Hardware — RAID Controller
+
+RAID controller inventory and state. Table: `component.raid_controller`.
+
+| Field | OID | MIB | Description |
+|---|---|---|---|
+| `component.raid_controller.index` | `1.3.6.1.4.1.674.10892.5.4.300.50.1.1` | iDRAC-MIB | Controller index |
+| `component.raid_controller.name` | `1.3.6.1.4.1.674.10892.5.4.300.50.1.5` | iDRAC-MIB | Controller model name |
+| `component.raid_controller.state` | `1.3.6.1.4.1.674.10892.5.4.300.50.1.4` | iDRAC-MIB | Controller state enum |
+
+---
+
+## UPS / Power
+
+Battery, input/output phase, and environment data for UPS devices. Source: **XUPS-MIB** (Eaton/Powerware).
+
+**GET scalars:**
+
+| Field | OID | MIB | Description |
+|---|---|---|---|
+| `ups.battery.time_remaining_seconds` | `1.3.6.1.4.1.534.1.2.1.0` | XUPS-MIB | Estimated runtime remaining on battery in seconds |
+| `ups.battery.voltage` | `1.3.6.1.4.1.534.1.2.2.0` | XUPS-MIB | Battery voltage (units per device config) |
+| `ups.battery.current_amps` | `1.3.6.1.4.1.534.1.2.3.0` | XUPS-MIB | Battery current in amps |
+| `ups.battery.capacity_pct` | `1.3.6.1.4.1.534.1.2.4.0` | XUPS-MIB | Battery charge level as percentage 0–100 |
+| `ups.battery.status` | `1.3.6.1.4.1.534.1.2.5.0` | XUPS-MIB | Battery status enum (unknown, batteryNormal, batteryLow, etc.) |
+| `ups.input.frequency_01hz` | `1.3.6.1.4.1.534.1.3.1.0` | XUPS-MIB | Input AC frequency in 0.1 Hz units |
+| `ups.input.line_bads` | `1.3.6.1.4.1.534.1.3.2.0` | XUPS-MIB | Count of times input power was out of tolerance |
+| `ups.input.num_phases` | `1.3.6.1.4.1.534.1.3.3.0` | XUPS-MIB | Number of input phases |
+| `ups.input.source` | `1.3.6.1.4.1.534.1.3.5.0` | XUPS-MIB | Current input power source enum |
+| `ups.output.num_phases` | `1.3.6.1.4.1.534.1.4.3.0` | XUPS-MIB | Number of output phases |
+| `ups.output.source` | `1.3.6.1.4.1.534.1.4.5.0` | XUPS-MIB | Output source enum (normal, battery, bypass, etc.) |
+| `ups.output.load_pct` | `1.3.6.1.4.1.534.1.4.6.0` | XUPS-MIB | Total output load as percentage of capacity |
+| `ups.env.temperature_c` | `1.3.6.1.4.1.534.1.6.1.0` | XUPS-MIB | Ambient temperature at UPS in Celsius |
+| `ups.env.humidity_pct` | `1.3.6.1.4.1.534.1.6.2.0` | XUPS-MIB | Ambient relative humidity percentage |
+| `ups.alarms.present` | `1.3.6.1.4.1.534.1.7.1.0` | XUPS-MIB | Number of active alarms currently set |
+
+**Table: `ups.input.phase`** — one row per input phase:
+
+| Field | OID | MIB | Description |
+|---|---|---|---|
+| `ups.input.phase.index` | `1.3.6.1.4.1.534.1.3.4.1.1` | XUPS-MIB | Phase index |
+| `ups.input.phase.voltage` | `1.3.6.1.4.1.534.1.3.4.1.2` | XUPS-MIB | Phase input voltage |
+| `ups.input.phase.current` | `1.3.6.1.4.1.534.1.3.4.1.4` | XUPS-MIB | Phase input current in amps |
+| `ups.input.phase.voltage_status` | `1.3.6.1.4.1.534.1.3.4.1.5` | XUPS-MIB | Per-phase voltage status enum |
+
+**Table: `ups.output.phase`** — one row per output phase:
+
+| Field | OID | MIB | Description |
+|---|---|---|---|
+| `ups.output.phase.index` | `1.3.6.1.4.1.534.1.4.4.1.1` | XUPS-MIB | Phase index |
+| `ups.output.phase.voltage` | `1.3.6.1.4.1.534.1.4.4.1.2` | XUPS-MIB | Phase output voltage |
+| `ups.output.phase.current` | `1.3.6.1.4.1.534.1.4.4.1.3` | XUPS-MIB | Phase output current in amps |
+| `ups.output.phase.load` | `1.3.6.1.4.1.534.1.4.4.1.4` | XUPS-MIB | Per-phase load |
+| `ups.output.phase.power` | `1.3.6.1.4.1.534.1.4.4.1.5` | XUPS-MIB | Per-phase output power in watts |
+
+---
+
+## Storage Volumes
+
+Per-volume I/O, capacity, and latency histograms. Table: `component.volume`. Source: **NIMBLE-MIB** (HPE Nimble).
+
+| Field | OID | MIB | Description |
+|---|---|---|---|
+| `component.volume.id` | `1.3.6.1.4.1.37447.1.2.1.2` | NIMBLE-MIB | Volume unique identifier |
+| `component.volume.name` | `1.3.6.1.4.1.37447.1.2.1.3` | NIMBLE-MIB | Volume name |
+| `component.volume.size.low` | `1.3.6.1.4.1.37447.1.2.1.4` | NIMBLE-MIB | Provisioned size low 32 bits |
+| `component.volume.size.high` | `1.3.6.1.4.1.37447.1.2.1.5` | NIMBLE-MIB | Provisioned size high 32 bits |
+| `component.volume.usage.low` | `1.3.6.1.4.1.37447.1.2.1.6` | NIMBLE-MIB | Space consumed by volume data low 32 bits |
+| `component.volume.usage.high` | `1.3.6.1.4.1.37447.1.2.1.7` | NIMBLE-MIB | Space consumed by volume data high 32 bits |
+| `component.volume.reserve.low` | `1.3.6.1.4.1.37447.1.2.1.8` | NIMBLE-MIB | Reserved space low 32 bits |
+| `component.volume.reserve.high` | `1.3.6.1.4.1.37447.1.2.1.9` | NIMBLE-MIB | Reserved space high 32 bits |
+| `component.volume.online` | `1.3.6.1.4.1.37447.1.2.1.10` | NIMBLE-MIB | Whether the volume is online |
+| `component.volume.connections` | `1.3.6.1.4.1.37447.1.2.1.11` | NIMBLE-MIB | Number of active iSCSI connections |
+| `component.volume.io.read.ops` | `1.3.6.1.4.1.37447.1.2.1.13` | NIMBLE-MIB | Total read I/O operations |
+| `component.volume.io.read.time_us` | `1.3.6.1.4.1.37447.1.2.1.14` | NIMBLE-MIB | Cumulative read service time in microseconds |
+| `component.volume.io.read.bytes` | `1.3.6.1.4.1.37447.1.2.1.15` | NIMBLE-MIB | Total bytes read |
+| `component.volume.io.read.seq_ops` | `1.3.6.1.4.1.37447.1.2.1.16` | NIMBLE-MIB | Sequential read I/O operations |
+| `component.volume.io.read.seq_bytes` | `1.3.6.1.4.1.37447.1.2.1.17` | NIMBLE-MIB | Bytes read sequentially |
+| `component.volume.io.read.cache_hits` | `1.3.6.1.4.1.37447.1.2.1.18` | NIMBLE-MIB | Total read cache hits |
+| `component.volume.io.read.cache_mem_hits` | `1.3.6.1.4.1.37447.1.2.1.19` | NIMBLE-MIB | Read hits served from DRAM cache |
+| `component.volume.io.read.cache_ssd_hits` | `1.3.6.1.4.1.37447.1.2.1.20` | NIMBLE-MIB | Read hits served from SSD cache |
+| `component.volume.io.read.latency.0us_100us` | `1.3.6.1.4.1.37447.1.2.1.21` | NIMBLE-MIB | Reads completing in < 100µs |
+| `component.volume.io.read.latency.1ms_2ms` | `1.3.6.1.4.1.37447.1.2.1.25` | NIMBLE-MIB | Reads completing in 1–2ms |
+| `component.volume.io.read.latency.5ms_10ms` | `1.3.6.1.4.1.37447.1.2.1.27` | NIMBLE-MIB | Reads completing in 5–10ms |
+| `component.volume.io.read.latency.20ms_50ms` | `1.3.6.1.4.1.37447.1.2.1.29` | NIMBLE-MIB | Reads completing in 20–50ms |
+| `component.volume.io.read.latency.500ms_max` | `1.3.6.1.4.1.37447.1.2.1.33` | NIMBLE-MIB | Reads completing in > 500ms |
+| `component.volume.io.write.ops` | `1.3.6.1.4.1.37447.1.2.1.34` | NIMBLE-MIB | Total write I/O operations |
+| `component.volume.io.write.time_us` | `1.3.6.1.4.1.37447.1.2.1.35` | NIMBLE-MIB | Cumulative write service time in microseconds |
+| `component.volume.io.write.bytes` | `1.3.6.1.4.1.37447.1.2.1.36` | NIMBLE-MIB | Total bytes written |
+| `component.volume.io.write.seq_ops` | `1.3.6.1.4.1.37447.1.2.1.37` | NIMBLE-MIB | Sequential write I/O operations |
+| `component.volume.io.write.seq_bytes` | `1.3.6.1.4.1.37447.1.2.1.38` | NIMBLE-MIB | Bytes written sequentially |
+| `component.volume.io.write.latency.0us_100us` | `1.3.6.1.4.1.37447.1.2.1.39` | NIMBLE-MIB | Writes completing in < 100µs |
+| `component.volume.io.write.latency.1ms_2ms` | `1.3.6.1.4.1.37447.1.2.1.43` | NIMBLE-MIB | Writes completing in 1–2ms |
+| `component.volume.io.write.latency.5ms_10ms` | `1.3.6.1.4.1.37447.1.2.1.45` | NIMBLE-MIB | Writes completing in 5–10ms |
+| `component.volume.io.write.latency.20ms_50ms` | `1.3.6.1.4.1.37447.1.2.1.47` | NIMBLE-MIB | Writes completing in 20–50ms |
+| `component.volume.io.write.latency.500ms_max` | `1.3.6.1.4.1.37447.1.2.1.51` | NIMBLE-MIB | Writes completing in > 500ms |
+| `component.volume.disk.vol_used.low` | `1.3.6.1.4.1.37447.1.2.1.52` | NIMBLE-MIB | Disk space used by volume data low 32 bits |
+| `component.volume.disk.vol_used.high` | `1.3.6.1.4.1.37447.1.2.1.53` | NIMBLE-MIB | Disk space used by volume data high 32 bits |
+| `component.volume.disk.snap_used.low` | `1.3.6.1.4.1.37447.1.2.1.54` | NIMBLE-MIB | Disk space used by snapshots low 32 bits |
+| `component.volume.disk.snap_used.high` | `1.3.6.1.4.1.37447.1.2.1.55` | NIMBLE-MIB | Disk space used by snapshots high 32 bits |
+
+---
+
+## Fibre Channel — Ports
+
+Per-port FC traffic and error counters. Source: **SW-MIB** (Brocade).
+
+**Table: `interface`** — FC port identity and traffic:
+
+| Field | OID | MIB | Description |
+|---|---|---|---|
+| `interface.index` | `1.3.6.1.4.1.1588.2.1.1.1.6.2.1.1` | SW-MIB | Port index |
+| `interface.name` | `1.3.6.1.4.1.1588.2.1.1.1.6.2.1.36` | SW-MIB | Port name string |
+| `interface.speed` | `1.3.6.1.4.1.1588.2.1.1.1.6.2.1.35` | SW-MIB | Negotiated FC link speed |
+| `interface.status.physical` | `1.3.6.1.4.1.1588.2.1.1.1.6.2.1.3` | SW-MIB | Physical port state enum |
+| `interface.traffic.in.frames` | `1.3.6.1.4.1.1588.2.1.1.1.6.2.1.2` | SW-MIB | FC frames received |
+| `interface.traffic.out.frames` | `1.3.6.1.4.1.1588.2.1.1.1.6.2.1.13` | SW-MIB | FC frames transmitted |
+
+**Table: `fibre_channel`** — FC error counters (same index as `interface`):
+
+| Field | OID | MIB | Description |
+|---|---|---|---|
+| `fibre_channel.index` | `1.3.6.1.4.1.1588.2.1.1.1.6.2.1.1` | SW-MIB | Port index |
+| `fibre_channel.wwn` | `1.3.6.1.4.1.1588.2.1.1.1.6.2.1.34` | SW-MIB | Port World Wide Name |
+| `fibre_channel.errors.in.crc` | `1.3.6.1.4.1.1588.2.1.1.1.6.2.1.4` | SW-MIB | Frames received with CRC errors |
+| `fibre_channel.errors.in.invalid_words` | `1.3.6.1.4.1.1588.2.1.1.1.6.2.1.5` | SW-MIB | Invalid transmission words received |
+| `fibre_channel.errors.link_failures` | `1.3.6.1.4.1.1588.2.1.1.1.6.2.1.6` | SW-MIB | Link failure count |
+| `fibre_channel.errors.loss_of_signal` | `1.3.6.1.4.1.1588.2.1.1.1.6.2.1.7` | SW-MIB | Loss of signal events |
+| `fibre_channel.errors.loss_of_sync` | `1.3.6.1.4.1.1588.2.1.1.1.6.2.1.8` | SW-MIB | Loss of sync events |
+| `fibre_channel.errors.in.encoding_disparity` | `1.3.6.1.4.1.1588.2.1.1.1.6.2.1.9` | SW-MIB | Encoding disparity errors received |
+| `fibre_channel.errors.out.link_resets` | `1.3.6.1.4.1.1588.2.1.1.1.6.2.1.10` | SW-MIB | Link reset primitives transmitted |
+
+---
+
+## Fibre Channel — Name Server
+
+Local FC name server (fabric directory). Table: `fibre_channel_name_server`. Source: **SW-MIB** (Brocade).
+
+| Field | OID | MIB | Description |
+|---|---|---|---|
+| `fibre_channel_name_server.index` | `1.3.6.1.4.1.1588.2.1.1.1.7.2.1.1` | SW-MIB | Name server entry index |
+| `fibre_channel_name_server.fcid` | `1.3.6.1.4.1.1588.2.1.1.1.7.2.1.2` | SW-MIB | Fibre Channel ID (24-bit fabric address) |
+| `fibre_channel_name_server.port.type` | `1.3.6.1.4.1.1588.2.1.1.1.7.2.1.3` | SW-MIB | Port type enum (N, NL, F, FL, E, etc.) |
+| `fibre_channel_name_server.wwpn` | `1.3.6.1.4.1.1588.2.1.1.1.7.2.1.4` | SW-MIB | Port World Wide Name |
+| `fibre_channel_name_server.port.description` | `1.3.6.1.4.1.1588.2.1.1.1.7.2.1.5` | SW-MIB | Port symbolic name |
+| `fibre_channel_name_server.wwnn` | `1.3.6.1.4.1.1588.2.1.1.1.7.2.1.6` | SW-MIB | Node World Wide Name |
+| `fibre_channel_name_server.node.description` | `1.3.6.1.4.1.1588.2.1.1.1.7.2.1.7` | SW-MIB | Node symbolic name |
+
+---
+
+## Printers
+
+Toner, page counts, trays, covers, and alerts. Source: **Printer-MIB** (RFC 3805).
+
+**GET scalars:**
+
+| Field | OID | MIB | Description |
+|---|---|---|---|
+| `observer.model` | `1.3.6.1.2.1.43.5.1.1.16.1` | Printer-MIB | Printer model name |
+| `observer.serial_number` | `1.3.6.1.2.1.43.5.1.1.17.1` | Printer-MIB | Printer serial number |
+
+**Table: `printer.supply`** — one row per consumable (toner, drum, fuser, etc.):
+
+| Field | OID | MIB | Description |
+|---|---|---|---|
+| `printer.supply.description` | `1.3.6.1.2.1.43.11.1.1.6` | Printer-MIB | Supply name (e.g. "Black Toner Cartridge") |
+| `printer.supply.unit` | `1.3.6.1.2.1.43.11.1.1.7` | Printer-MIB | Unit of measure enum for `level` and `capacity_max` |
+| `printer.supply.capacity_max` | `1.3.6.1.2.1.43.11.1.1.8` | Printer-MIB | Maximum capacity in `unit` units (-2 = unknown) |
+| `printer.supply.level` | `1.3.6.1.2.1.43.11.1.1.9` | Printer-MIB | Current supply level (-3 = at least some remaining) |
+
+**Table: `printer.marker`** — one row per print engine:
+
+| Field | OID | MIB | Description |
+|---|---|---|---|
+| `printer.marker.pages_lifetime` | `1.3.6.1.2.1.43.10.2.1.4` | Printer-MIB | Total pages printed since manufacture |
+| `printer.marker.pages_power_on` | `1.3.6.1.2.1.43.10.2.1.5` | Printer-MIB | Pages printed since last power-on |
+
+**Table: `printer.tray`** — one row per paper input tray:
+
+| Field | OID | MIB | Description |
+|---|---|---|---|
+| `printer.tray.name` | `1.3.6.1.2.1.43.8.2.1.13` | Printer-MIB | Tray name |
+| `printer.tray.level` | `1.3.6.1.2.1.43.8.2.1.9` | Printer-MIB | Current paper level |
+| `printer.tray.capacity_max` | `1.3.6.1.2.1.43.8.2.1.10` | Printer-MIB | Maximum tray capacity |
+
+**Table: `printer.cover`** — one row per door/cover:
+
+| Field | OID | MIB | Description |
+|---|---|---|---|
+| `printer.cover.description` | `1.3.6.1.2.1.43.6.1.1.2` | Printer-MIB | Cover name |
+| `printer.cover.status` | `1.3.6.1.2.1.43.6.1.1.3` | Printer-MIB | Cover state: 1=other, 3=open, 4=closed |
+
+**Table: `printer.alert`** — one row per active alert:
+
+| Field | OID | MIB | Description |
+|---|---|---|---|
+| `printer.alert.code` | `1.3.6.1.2.1.43.15.1.1.2` | Printer-MIB | Alert code enum (jammed, tonerLow, offline, etc.) |
+| `printer.alert.description` | `1.3.6.1.2.1.43.15.1.1.3` | Printer-MIB | Human-readable alert description |

--- a/src/logstashui/SNMP/snmp_pipeline_generator.py
+++ b/src/logstashui/SNMP/snmp_pipeline_generator.py
@@ -938,9 +938,15 @@ def _get_device_profiles(device, profile_cache=None):
         if 'table' in profile_data and isinstance(profile_data['table'], dict):
             merged_oids['table'].update(profile_data['table'])
         
-        # Collect normalizers from this profile
-        if 'normalizers' in profile_data and isinstance(profile_data['normalizers'], list):
-            all_normalizers.extend(profile_data['normalizers'])
+        # Collect normalizers from this profile.
+        # FIX (MA 2026-06-19): official profiles carry normalizers inline in profile_data (loaded
+        # from disk JSON), but USER-authored profiles store them in the separate `normalizers` model
+        # column -> they were being dropped from generated pipelines. Fall back to the model field.
+        prof_norms = profile_data.get('normalizers')
+        if not prof_norms:
+            prof_norms = getattr(profile, 'normalizers', None) or []
+        if isinstance(prof_norms, list):
+            all_normalizers.extend(prof_norms)
 
     return (profile_ids, merged_oids, all_normalizers)
 

--- a/src/logstashui/Site/templates/navigation.html
+++ b/src/logstashui/Site/templates/navigation.html
@@ -205,6 +205,17 @@
                 <span class="nav-text">Integration Factory</span>
               </a>
             </li>
+            <li>
+              <a href="/AI/Onboarding/"
+                class="nav-item {% if '/AI/Onboarding' in request.path %}active{% endif %}">
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24"
+                  stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                    d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+                <span class="nav-text">AI Onboarding</span>
+              </a>
+            </li>
           </ul>
         </details>
       </li>


### PR DESCRIPTION
Combined release branch: AI Device Onboarding (discover → author → approve → deploy) with normalizers flowing end-to-end.

## What's included
- **AI Device Onboarding** (experimental, `/AI/Onboarding/`): `AISettings` + `DraftDefinition` models, `agent_client` (Agent Builder converse), `snmp_discovery` (live grounding walk), Generate/Approve/Reject views + UI. `ApproveDraft` creates the Profile + DeviceTemplate server-side, gated by human approval.
- **Normalizers end-to-end**: authored `normalizers[]` captured from the agent → `DraftDefinition.normalizers` (migration `AI/0002`) → `Profile.normalizers` on approve → generated Logstash pipeline. Metrics ship scaled/decoded.
- **Fix**: `_get_device_profiles` no longer drops user/AI-authored profile normalizers (falls back to the `Profile.normalizers` column, not just inline `profile_data`).
- **Docs**: `docs/docs/logstashui/ai-device-onboarding.md` — build/deploy runbook incl. the LogstashUI-as-source-of-truth KB sync.

## Deploy notes
Agent + KB tooling live in the SNMP AB-tool. The `snmp-definitions-kb` the agent grounds on must be synced from this repo (source of truth) — `load-kb.py --prune` (exact mirror) + `--check` (drift gate). See the runbook.

## Known follow-ups
- Device-dedup guards deferred to a separate PR.
- Spec drift: profiles/agent use `translate` (and `average`); reconcile `spec/normalizers.0.5.0.json` + generator (`average` has no handler yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)