### PR TITLE
fix(snmp): scope-qualify multiply/ratio normalizer filter IDs

### DIFF
--- a/src/logstashui/SNMP/snmp_normalizers.py
+++ b/src/logstashui/SNMP/snmp_normalizers.py
@@ -40,7 +40,7 @@ def _apply_normalizers(normalizers):
         for scope, normalizer_list in scopes.items():
             if operation == 'multiply':
                 if scope in ('get', 'table'):
-                    filter_components = _generate_multiply_get_filter(normalizer_list)
+                    filter_components = _generate_multiply_get_filter(normalizer_list, scope)
                     if filter_components:
                         # Filter generators now return lists (comment + filter)
                         if isinstance(filter_components, list):
@@ -49,7 +49,7 @@ def _apply_normalizers(normalizers):
                             filters.append(filter_components)
             elif operation == 'ratio':
                 if scope in ('get', 'table'):
-                    filter_components = _generate_ratio_get_filter(normalizer_list)
+                    filter_components = _generate_ratio_get_filter(normalizer_list, scope)
                     if filter_components:
                         # Filter generators now return lists (comment + filter)
                         if isinstance(filter_components, list):
@@ -68,14 +68,19 @@ def _apply_normalizers(normalizers):
     return filters
 
 
-def _generate_multiply_get_filter(normalizers):
+def _generate_multiply_get_filter(normalizers, scope='get'):
     """
-    Generate Ruby filter for multiply operations on get fields.
+    Generate Ruby filter for multiply operations on get or table fields.
     Consolidates multiple multiply operations into a single Ruby filter.
-    
+
     Args:
-        normalizers: List of multiply normalizers for get scope
-        
+        normalizers: List of multiply normalizers for the given scope
+        scope: Target scope ('get' or 'table'), used to keep generated
+            Logstash filter component IDs unique across scopes so a
+            get-scope multiply and a table-scope multiply on the same
+            profile don't emit duplicate plugin IDs (Logstash rejects
+            pipelines with duplicate IDs at compile time).
+
     Returns:
         Logstash filter component dict
     """
@@ -123,7 +128,7 @@ def _generate_multiply_get_filter(normalizers):
     
     return [
         {
-            "id": "normalizer_multiply_get_comment",
+            "id": f"normalizer_multiply_{scope}_comment",
             "type": "filter",
             "plugin": "comment",
             "config": {
@@ -131,7 +136,7 @@ def _generate_multiply_get_filter(normalizers):
             }
         },
         {
-            "id": "normalizer_multiply_get",
+            "id": f"normalizer_multiply_{scope}",
             "type": "filter",
             "plugin": "ruby",
             "config": {
@@ -141,14 +146,19 @@ def _generate_multiply_get_filter(normalizers):
     ]
 
 
-def _generate_ratio_get_filter(normalizers):
+def _generate_ratio_get_filter(normalizers, scope='get'):
     """
-    Generate Ruby filter for ratio operations on get fields.
+    Generate Ruby filter for ratio operations on get or table fields.
     Calculates ratios from two input fields and optionally creates total and ratio output fields.
-    
+
     Args:
-        normalizers: List of ratio normalizers for get scope
-        
+        normalizers: List of ratio normalizers for the given scope
+        scope: Target scope ('get' or 'table'), used to keep generated
+            Logstash filter component IDs unique across scopes so a
+            get-scope ratio and a table-scope ratio on the same profile
+            don't emit duplicate plugin IDs (Logstash rejects pipelines
+            with duplicate IDs at compile time).
+
     Returns:
         Logstash filter component dict
     """
@@ -253,7 +263,7 @@ def _generate_ratio_get_filter(normalizers):
     
     return [
         {
-            "id": "normalizer_ratio_get_comment",
+            "id": f"normalizer_ratio_{scope}_comment",
             "type": "filter",
             "plugin": "comment",
             "config": {
@@ -261,7 +271,7 @@ def _generate_ratio_get_filter(normalizers):
             }
         },
         {
-            "id": "normalizer_ratio_get",
+            "id": f"normalizer_ratio_{scope}",
             "type": "filter",
             "plugin": "ruby",
             "config": {

--- a/src/logstashui/SNMP/tests/test_snmp_normalizers.py
+++ b/src/logstashui/SNMP/tests/test_snmp_normalizers.py
@@ -449,3 +449,98 @@ class TestApplyNormalizers:
         ]
         result = _apply_normalizers(normalizers)
         assert len(result) > 0
+
+
+# ===========================================================================
+# Scope-qualified filter IDs (regression: duplicate Logstash plugin IDs)
+# ===========================================================================
+
+class TestScopeQualifiedFilterIds:
+    """
+    _generate_multiply_get_filter / _generate_ratio_get_filter run for BOTH
+    'get' and 'table' scope normalizers, so their generated Logstash filter
+    component IDs must be scope-qualified. Otherwise a profile pairing a
+    get-scope op with a table-scope op of the same type emits two components
+    with an identical plugin ID, and Logstash rejects pipelines with duplicate
+    plugin IDs at compile time (the merged pipeline never builds).
+    """
+
+    # Mirrors cisco_system_metrics.json (get scope) combined with a Cisco
+    # OpenConfig interface-table profile (table scope).
+    GET_MULTIPLY = {
+        'operation': 'multiply',
+        'target': {'scope': 'get', 'field': 'system.cpu.total.norm.pct'},
+        'params': {'multiply_value': 0.01},
+    }
+    TABLE_MULTIPLY = {
+        'operation': 'multiply',
+        'target': {'scope': 'table', 'field': 'interface.state.speed'},
+        'params': {'multiply_value': 1000000},
+    }
+    GET_RATIO = {
+        'operation': 'ratio',
+        'target': {'scope': 'get'},
+        'params': {
+            'value1_field': 'system.memory.actual.used.bytes',
+            'value2_field': 'system.memory.actual.free.bytes',
+            'total_output_field': 'system.memory.total.bytes',
+            'ratio1_output_field': 'system.memory.actual.used.pct',
+        },
+    }
+    TABLE_RATIO = {
+        'operation': 'ratio',
+        'target': {'scope': 'table'},
+        'params': {
+            'value1_field': 'interface.state.counters.in_octets',
+            'value2_field': 'interface.state.counters.out_octets',
+            'total_output_field': 'interface.state.counters.total_octets',
+        },
+    }
+
+    @staticmethod
+    def _assert_unique(components):
+        ids = [c['id'] for c in components]
+        dupes = sorted({i for i in ids if ids.count(i) > 1})
+        assert not dupes, f"duplicate filter component IDs: {dupes}"
+
+    def test_multiply_get_and_table_scope_ids_are_scope_qualified(self):
+        components = _apply_normalizers([self.GET_MULTIPLY, self.TABLE_MULTIPLY])
+        self._assert_unique(components)
+        ids = [c['id'] for c in components]
+        assert 'normalizer_multiply_get' in ids
+        assert 'normalizer_multiply_table' in ids
+        assert 'normalizer_multiply_get_comment' in ids
+        assert 'normalizer_multiply_table_comment' in ids
+
+    def test_ratio_get_and_table_scope_ids_are_scope_qualified(self):
+        components = _apply_normalizers([self.GET_RATIO, self.TABLE_RATIO])
+        self._assert_unique(components)
+        ids = [c['id'] for c in components]
+        assert 'normalizer_ratio_get' in ids
+        assert 'normalizer_ratio_table' in ids
+        assert 'normalizer_ratio_get_comment' in ids
+        assert 'normalizer_ratio_table_comment' in ids
+
+    def test_combined_profile_all_component_ids_unique(self):
+        # The exact scenario that triggered the bug: cisco_system_metrics
+        # (get-scope CPU multiply + memory ratio) merged with a Cisco
+        # OpenConfig interface-table profile (table-scope multiply + ratio).
+        components = _apply_normalizers(
+            [self.GET_MULTIPLY, self.GET_RATIO, self.TABLE_MULTIPLY, self.TABLE_RATIO]
+        )
+        self._assert_unique(components)
+        ids = [c['id'] for c in components]
+        for expected in (
+            'normalizer_multiply_get',
+            'normalizer_multiply_table',
+            'normalizer_ratio_get',
+            'normalizer_ratio_table',
+        ):
+            assert expected in ids, f"missing generated component: {expected}"
+
+    def test_single_get_scope_multiply_keeps_stable_id(self):
+        # A lone get-scope multiply keeps the historical un-suffixed id so the
+        # fix stays behavior-preserving for the common single-scope case.
+        components = _apply_normalizers([self.GET_MULTIPLY])
+        ids = [c['id'] for c in components]
+        assert ids == ['normalizer_multiply_get_comment', 'normalizer_multiply_get']


### PR DESCRIPTION
## Problem

`_apply_normalizers()` calls `_generate_multiply_get_filter()` and `_generate_ratio_get_filter()` for **both** `get`- and `table`-scope normalizers (despite the `_get_` in their names), but each generator **hardcoded** its Logstash filter component IDs (`normalizer_multiply_get[_comment]`, `normalizer_ratio_get[_comment]`) regardless of the scope passed in.

A device template pairing a **get-scope multiply** (e.g. CPU% scale factor from `cisco_system_metrics.json`) with a **table-scope multiply** (e.g. interface speed Mbps→bps from a Cisco OpenConfig interface profile) emits two filter components with the identical id `normalizer_multiply_get`. **Logstash rejects pipelines with duplicate plugin IDs at compile time**, so the merged pipeline never builds. The ratio generator had the same latent collision.

This blocks deploying the Cisco OpenConfig interfaces profile (table-scope speed multiply) alongside `cisco_system_metrics` (get-scope CPU multiply).

## Fix

Thread `scope` through both generators and interpolate it into the IDs (`f"normalizer_multiply_{scope}"`, `f"normalizer_ratio_{scope}"`, and their `_comment` siblings), and pass `scope` at both call sites. `scope` defaults to `'get'`, so existing single-arg callers and tests are unaffected — get-scope keeps `normalizer_multiply_get`; table-scope now correctly emits `normalizer_multiply_table`. No behavior change beyond the IDs.

`_generate_translate_filter` already derives its IDs from the field name, so it doesn't share this collision pattern (left untouched).

## Verification

Added `TestScopeQualifiedFilterIds` to `test_snmp_normalizers.py`: pairs get- and table-scope multiply/ratio (mirroring `cisco_system_metrics.json` × a Cisco OpenConfig interface-table profile) and asserts all generated component IDs are unique, plus pins the stable single-get-scope id.

- **Proven to catch the bug**: the multi-scope tests fail against the pre-fix code with exactly `duplicate filter component IDs: ['normalizer_multiply_get', 'normalizer_multiply_get_comment']` (and the ratio equivalent), and pass after the fix.
- **No regressions**: full SNMP suite `436 passed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)