### PR TITLE
fix(snmp): device panel showed no CPU/memory and grey interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -213,8 +213,9 @@
 - Fixed missing RBAC protection across SNMP administrative operations.
 - Fixed installation-asset actions, loading indicators, and cleanup behavior in AI template and profile generation.
 - Fixed various SNMP CRUD, rendering, deployment, and code-quality issues discovered during final release testing.
-
-
+- Fixed the device CPU chart rendering empty whenever a device reported no memory percentage; CPU and memory are now collected independently instead of from a single document.
+- Fixed devices with no derived `system.memory.actual.used.pct` showing no memory chart, by falling back to the `hrStorageRam` row of `hrStorageTable`, selected by storage type and lowest `hrStorageIndex` so physical memory is used rather than a cache or buffers row. That figure includes reclaimable cache, so the chart is labelled accordingly and the response reports its source.
+- Fixed interfaces on OpenConfig-shaped documents always rendering as grey "Unknown" with zeroed traffic counters, by flattening `interface.state` and `interface.state.counters` onto the interface object the UI reads, preferring already-normalized values.
 
 ## [0.4.3] - AI Foundation, Simulation Improvements, and SNMP Fixes - 06/07/2026
 

--- a/src/logstashui/SNMP/snmp_crud.py
+++ b/src/logstashui/SNMP/snmp_crud.py
@@ -3141,6 +3141,11 @@ def GetAllProfiles(request):
         return JsonResponse({'success': False, 'message': str(e)}, status=500)
 
 
+# hrStorageRam — the HOST-RESOURCES-MIB storage type identifying a physical
+# memory row, as carried in system.filesystem.type.
+HR_STORAGE_RAM_OID = "1.3.6.1.2.1.25.2.1.2"
+
+
 def _device_host_filter(device):
     """Return an ES filter matching a device by its SNMP poll address.
 
@@ -3519,18 +3524,47 @@ def _get_device_interfaces(device, es_connection):
 
     for fan in results['aggregations']['fans']['buckets']:
         for doc in fan['top_if_doc']['hits']['hits']:
-            visualization_data['interfaces'].append(doc['_source']['interface'])
+            visualization_data['interfaces'].append(
+                _flatten_interface(doc['_source']['interface'])
+            )
 
     return visualization_data
 
 
+def _flatten_interface(interface):
+    """Flatten an OpenConfig-shaped interface doc to what the frontend reads.
+
+    SNMP-polled interfaces arrive flat (``interface.oper_status``), but
+    OpenConfig/gNMI-shaped ones nest the same values under ``state``, with the
+    traffic counters nested one level deeper again under ``state.counters``.
+    The UI reads every one of these off the interface object directly
+    (``iface.oper_status``, ``iface.in_octets``), so lift both levels.
+
+    Existing top-level keys win: the SNMP pipeline's translate normalizers have
+    already decoded those (2 -> "DOWN"), whereas a raw ``state`` value may still
+    be the undecoded integer, which the UI would render as "Unknown".
+    """
+    iface = dict(interface)
+    state = iface.pop('state', None)
+    if not state:
+        return iface
+
+    flattened = dict(state)
+    # Counters sit at state.counters.* but are read as iface.in_octets etc.
+    counters = flattened.pop('counters', None)
+    if isinstance(counters, dict):
+        flattened.update(counters)
+
+    flattened.update(iface)
+    return flattened
+
+
 def _get_device_metrics(device, es_connection):
-    results = es_connection.search(
+    cpu_results = es_connection.search(
         size=1000,
         index="metrics-snmp*",
         sort=[{"@timestamp": {"order": "desc"}}],
         query={
-
             "bool": {
                 "filter": [
                     {
@@ -3554,25 +3588,117 @@ def _get_device_metrics(device, es_connection):
     visualization_data = {
         "Uptime": 0,
         "CPU": [],
+        "CPUTime": [],
         "Memory": [],
-        "Time": []
+        "MemoryTime": [],
+        "MemorySource": None
     }
 
-    for result in results['hits']['hits']:
+    for result in cpu_results['hits']['hits']:
         try:
             cpu = result['_source']['system']['cpu']['total']['norm']['pct']
-            memory = result['_source']['system']['memory']['actual']['used']['pct']
-            timestamp = result['_source']['@timestamp']
-
             visualization_data['CPU'].append(cpu)
-            visualization_data['Memory'].append(memory)
-            visualization_data['Time'].append(timestamp)
+            visualization_data['CPUTime'].append(result['_source']['@timestamp'])
         except (KeyError, TypeError):
-            # Skip documents that don't have the required CPU/Memory fields
+            # Skip documents that don't have the required CPU field
             continue
 
+    # Memory is normally the canonical system.memory.actual.used.pct, derived by a
+    # profile normalizer, and it rides the same metrics doc as CPU.
+    for result in cpu_results['hits']['hits']:
+        try:
+            memory = result['_source']['system']['memory']['actual']['used']['pct']
+            visualization_data['Memory'].append(memory)
+            visualization_data['MemoryTime'].append(result['_source']['@timestamp'])
+        except (KeyError, TypeError):
+            # Skip documents that don't have the required memory field
+            continue
+
+    if visualization_data['Memory']:
+        visualization_data['MemorySource'] = 'system.memory.actual.used.pct'
+    else:
+        # Profiles built only on HOST-RESOURCES-MIB derive no memory percentage.
+        # There, RAM is reported as a row of the same storage table as filesystem
+        # mounts, so fall back to it. Note hrStorageUsed counts reclaimable cache
+        # and buffers, so this reads higher than the normalizer-derived field —
+        # MemorySource lets the UI label which quantity is being shown.
+        # A device typically exposes several hrStorageRam rows (physical, buffers,
+        # cache, unavailable) that all report the SAME total, so bucket per poll and
+        # take the lowest hrStorageIndex — physical memory is the first RAM entry
+        # ("RAM" on EOS, "Physical memory" on net-snmp, both index 1). Aggregating
+        # rather than paging avoids a size cap that would silently truncate the
+        # series once multiplied by the number of RAM rows.
+        memory_results = es_connection.search(
+            size=0,
+            index="metrics-snmp*",
+            query={
+                "bool": {
+                    "filter": [
+                        {
+                            "range": {
+                                "@timestamp": {
+                                    "gte": "now-6h"
+                                }
+                            }
+                        },
+                        _device_host_filter(device),
+                        {
+                            "term": {
+                                "event.category": "system.filesystem"
+                            }
+                        },
+                        # Select RAM rows by hrStorageType, not by the free-text
+                        # description, which is agent- and locale-specific. Matched
+                        # against both the bare field and its .keyword subfield
+                        # because the mapping differs between the shipped index
+                        # template (keyword) and ES dynamic defaults (text+keyword).
+                        {
+                            "bool": {
+                                "should": [
+                                    {"term": {"system.filesystem.type": HR_STORAGE_RAM_OID}},
+                                    {"term": {"system.filesystem.type.keyword": HR_STORAGE_RAM_OID}}
+                                ],
+                                "minimum_should_match": 1
+                            }
+                        }
+                    ]
+                }
+            },
+            aggregations={
+                "by_poll": {
+                    "terms": {
+                        "field": "@timestamp",
+                        "size": 1000,
+                        "order": {"_key": "desc"}
+                    },
+                    "aggregations": {
+                        "physical": {
+                            "top_hits": {
+                                "size": 1,
+                                "sort": [{"system.filesystem.index": {"order": "asc"}}],
+                                "_source": ["@timestamp", "system.filesystem.used.pct"]
+                            }
+                        }
+                    }
+                }
+            }
+        )
+
+        buckets = memory_results.get('aggregations', {}).get('by_poll', {}).get('buckets', [])
+        for bucket in buckets:
+            for doc in bucket['physical']['hits']['hits']:
+                try:
+                    pct = doc['_source']['system']['filesystem']['used']['pct']
+                except (KeyError, TypeError):
+                    continue
+                visualization_data['Memory'].append(pct)
+                visualization_data['MemoryTime'].append(doc['_source']['@timestamp'])
+
+        if visualization_data['Memory']:
+            visualization_data['MemorySource'] = 'hrStorageRam'
+
     try:
-        visualization_data['Uptime'] = results['hits']['hits'][0]['_source']['host']['uptime']
+        visualization_data['Uptime'] = cpu_results['hits']['hits'][0]['_source']['host']['uptime']
     except (KeyError, TypeError, IndexError):
         visualization_data['Uptime'] = 0
 

--- a/src/logstashui/SNMP/static/js/snmp_device_visual_preview.js
+++ b/src/logstashui/SNMP/static/js/snmp_device_visual_preview.js
@@ -155,10 +155,10 @@ function renderDevicePreview(deviceId, device, visualizations) {
 
     // Render CPU chart
     const cpuChartCanvas = contentDiv.querySelector('.metric-cpu-chart');
-    if (metrics.CPU && metrics.Time && metrics.CPU.length > 0) {
+    if (metrics.CPU && metrics.CPUTime && metrics.CPU.length > 0) {
       renderMetricChart(
         cpuChartCanvas,
-        metrics.Time,
+        metrics.CPUTime,
         metrics.CPU,
         'CPU Usage (%)',
         'rgba(59, 130, 246, 1)', // Blue
@@ -167,24 +167,29 @@ function renderDevicePreview(deviceId, device, visualizations) {
     } else if (cpuChartCanvas) {
       // Show message when CPU data is not available
       const chartContainer = cpuChartCanvas.parentElement;
-      chartContainer.innerHTML = '<div class="flex items-center justify-center h-full text-gray-400 text-sm italic">Could not find system.cpu.total.norm.pct</div>';
+      chartContainer.innerHTML = '<div class="flex items-center justify-center h-full text-gray-400 text-sm italic">No CPU usage data collected for this device</div>';
     }
 
     // Render Memory chart
     const memoryChartCanvas = contentDiv.querySelector('.metric-memory-chart');
-    if (metrics.Memory && metrics.Time && metrics.Memory.length > 0) {
+    if (metrics.Memory && metrics.MemoryTime && metrics.Memory.length > 0) {
+      // hrStorageRam counts reclaimable cache/buffers, so it reads higher than the
+      // normalizer-derived field. Label it rather than passing it off as the same.
+      const memoryLabel = metrics.MemorySource === 'hrStorageRam'
+        ? 'Memory Usage (%) — incl. cache/buffers'
+        : 'Memory Usage (%)';
       renderMetricChart(
         memoryChartCanvas,
-        metrics.Time,
+        metrics.MemoryTime,
         metrics.Memory,
-        'Memory Usage (%)',
+        memoryLabel,
         'rgba(16, 185, 129, 1)', // Green
         'rgba(16, 185, 129, 0.1)'
       );
     } else if (memoryChartCanvas) {
       // Show message when Memory data is not available
       const chartContainer = memoryChartCanvas.parentElement;
-      chartContainer.innerHTML = '<div class="flex items-center justify-center h-full text-gray-400 text-sm italic">Could not find system.memory.actual.used.pct</div>';
+      chartContainer.innerHTML = '<div class="flex items-center justify-center h-full text-gray-400 text-sm italic">No memory usage data collected for this device</div>';
     }
   }
 

--- a/src/logstashui/SNMP/tests/test_snmp_crud.py
+++ b/src/logstashui/SNMP/tests/test_snmp_crud.py
@@ -2155,3 +2155,245 @@ class TestBuildNetworkPipelineConfigs:
             config = r['config']
             assert 'input {' in config
             assert 'output {' in config
+
+
+@pytest.mark.django_db
+class TestDeviceVisualizationData:
+    """Regression tests for device visualization data shaping.
+
+    Covers the defects that left the device detail panel blank or wrong while the
+    underlying data was present: interface values nested under OpenConfig's
+    ``state``, and memory being sourced from the wrong place.
+    """
+
+    def _search_stub(self, by_category, captured=None):
+        """Build an es.search side_effect that dispatches on event.category."""
+        def search(**kwargs):
+            filters = kwargs['query']['bool']['filter']
+            if captured is not None:
+                captured.append(filters)
+            categories = [f['term']['event.category'] for f in filters
+                          if 'term' in f and 'event.category' in f['term']]
+            for category in categories:
+                if category in by_category:
+                    return {'hits': {'hits': by_category[category]}}
+            return {'hits': {'hits': []}}
+        return search
+
+    # ---- interface shaping ----
+
+    def test_interfaces_flatten_openconfig_state_and_counters(self, test_device):
+        """state.* AND state.counters.* are lifted to where the UI reads them."""
+        from SNMP.snmp_crud import _get_device_interfaces
+
+        mock_es = MagicMock()
+        mock_es.search.return_value = {
+            'aggregations': {'fans': {'buckets': [
+                {'top_if_doc': {'hits': {'hits': [{'_source': {'interface': {
+                    'name': 'Ethernet1',
+                    'index': 1,
+                    'state': {
+                        'admin_status': 'UP',
+                        'oper_status': 'DOWN',
+                        'speed': 1000000000.0,
+                        'counters': {'in_octets': 42, 'out_errors': 7},
+                    },
+                }}}]}}},
+            ]}}
+        }
+
+        iface = _get_device_interfaces(test_device, mock_es)['interfaces'][0]
+
+        assert iface['admin_status'] == 'UP'
+        assert iface['oper_status'] == 'DOWN'
+        assert iface['speed'] == 1000000000.0
+        # Counters must be flat — createInterfaceCard reads iface.in_octets, so
+        # leaving them at iface.counters.in_octets renders 0 B on a busy link.
+        assert iface['in_octets'] == 42
+        assert iface['out_errors'] == 7
+        assert iface['name'] == 'Ethernet1'
+        assert iface['index'] == 1
+        assert 'state' not in iface
+
+    def test_normalized_top_level_status_wins_over_raw_state(self, test_device):
+        """A raw state value must not clobber the pipeline-normalized one."""
+        from SNMP.snmp_crud import _get_device_interfaces
+
+        mock_es = MagicMock()
+        mock_es.search.return_value = {
+            'aggregations': {'fans': {'buckets': [
+                {'top_if_doc': {'hits': {'hits': [{'_source': {'interface': {
+                    'name': 'Ethernet1',
+                    # Translate normalizer already decoded 1 -> UP here.
+                    'oper_status': 'UP',
+                    # ...while the raw enum survives under state.
+                    'state': {'oper_status': 1, 'admin_status': 'UP'},
+                }}}]}}},
+            ]}}
+        }
+
+        iface = _get_device_interfaces(test_device, mock_es)['interfaces'][0]
+
+        # The UI compares strictly against 'UP'; the raw 1 would render "Unknown".
+        assert iface['oper_status'] == 'UP'
+        # Keys only present under state still come through.
+        assert iface['admin_status'] == 'UP'
+
+    def test_interfaces_without_state_are_passed_through(self, test_device):
+        """A device that already reports flat status is left alone."""
+        from SNMP.snmp_crud import _get_device_interfaces
+
+        mock_es = MagicMock()
+        mock_es.search.return_value = {
+            'aggregations': {'fans': {'buckets': [
+                {'top_if_doc': {'hits': {'hits': [{'_source': {'interface': {
+                    'name': 'Ethernet1', 'admin_status': 'UP', 'oper_status': 'UP',
+                }}}]}}},
+            ]}}
+        }
+
+        iface = _get_device_interfaces(test_device, mock_es)['interfaces'][0]
+        assert iface['admin_status'] == 'UP'
+        assert iface['oper_status'] == 'UP'
+
+    # ---- metrics sourcing ----
+
+    def test_canonical_memory_field_is_preferred(self, test_device):
+        """Profiles deriving system.memory.actual.used.pct keep working."""
+        from SNMP.snmp_crud import _get_device_metrics
+
+        captured = []
+        mock_es = MagicMock()
+        mock_es.search.side_effect = self._search_stub({
+            'metrics': [{'_source': {
+                '@timestamp': '2026-08-04T01:00:00Z',
+                'system': {
+                    'cpu': {'total': {'norm': {'pct': 0.25}}},
+                    'memory': {'actual': {'used': {'pct': 0.19}}},
+                },
+                'host': {'uptime': 12345},
+            }}],
+        }, captured)
+
+        metrics = _get_device_metrics(test_device, mock_es)
+
+        assert metrics['CPU'] == [0.25]
+        assert metrics['Memory'] == [0.19]
+        assert metrics['MemorySource'] == 'system.memory.actual.used.pct'
+        assert metrics['Uptime'] == 12345
+        # The storage-table fallback must not be queried when the canonical
+        # field is present — that query is pure overhead here.
+        queried = [f['term']['event.category'] for fl in captured for f in fl
+                   if 'term' in f and 'event.category' in f['term']]
+        assert 'system.filesystem' not in queried
+
+    def test_cpu_returned_when_memory_is_absent(self, test_device):
+        """CPU must survive on its own — it used to be dropped with memory."""
+        from SNMP.snmp_crud import _get_device_metrics
+
+        mock_es = MagicMock()
+        mock_es.search.side_effect = self._search_stub({
+            'metrics': [{'_source': {
+                '@timestamp': '2026-08-04T01:00:00Z',
+                'system': {'cpu': {'total': {'norm': {'pct': 0.25}}}},
+                'host': {'uptime': 12345},
+            }}],
+        })
+
+        metrics = _get_device_metrics(test_device, mock_es)
+
+        assert metrics['CPU'] == [0.25]
+        assert metrics['CPUTime'] == ['2026-08-04T01:00:00Z']
+        assert metrics['Memory'] == []
+        assert metrics['MemorySource'] is None
+
+    def test_memory_falls_back_to_physical_hrstorage_ram_row(self, test_device):
+        """Without the canonical field, use hrStorageRam — physical, not cache."""
+        from SNMP.snmp_crud import _get_device_metrics
+
+        captured = []
+
+        def search(**kwargs):
+            filters = kwargs['query']['bool']['filter']
+            captured.append(filters)
+            categories = [f['term']['event.category'] for f in filters
+                          if 'term' in f and 'event.category' in f['term']]
+            if 'metrics' in categories:
+                return {'hits': {'hits': [{'_source': {
+                    '@timestamp': '2026-08-04T01:00:00Z',
+                    'system': {'cpu': {'total': {'norm': {'pct': 0.25}}}},
+                }}]}}
+            # The aggregation asks for the lowest hrStorageIndex per poll, so the
+            # physical row is what comes back — cache/buffers rows are ranked out
+            # by the sort, which is the behaviour being pinned here.
+            return {'aggregations': {'by_poll': {'buckets': [
+                {'key': 1, 'physical': {'hits': {'hits': [{'_source': {
+                    '@timestamp': '2026-08-04T01:00:00Z',
+                    'system': {'filesystem': {'used': {'pct': 0.98}}},
+                }}]}}},
+            ]}}}
+
+        mock_es = MagicMock()
+        mock_es.search.side_effect = search
+
+        metrics = _get_device_metrics(test_device, mock_es)
+
+        assert metrics['Memory'] == [0.98]
+        assert metrics['MemoryTime'] == ['2026-08-04T01:00:00Z']
+        assert metrics['MemorySource'] == 'hrStorageRam'
+
+        fs_filters = [fl for fl in captured
+                      if any('term' in f and f['term'].get('event.category') == 'system.filesystem'
+                             for f in fl)]
+        assert fs_filters, "expected a system.filesystem query"
+
+        # Rows are selected by hrStorageType, not by a locale-specific description
+        # ("RAM" on EOS vs "Physical memory" on net-snmp), and matched under both
+        # possible mappings of that field.
+        shoulds = [f['bool']['should'] for f in fs_filters[0] if 'bool' in f]
+        assert shoulds, "expected a bool/should type filter"
+        fields = {list(clause['term'].keys())[0] for clause in shoulds[0]}
+        assert fields == {'system.filesystem.type', 'system.filesystem.type.keyword'}
+        assert all(list(c['term'].values())[0] == '1.3.6.1.2.1.25.2.1.2' for c in shoulds[0])
+        assert not any('mount_point' in str(f) for f in fs_filters[0])
+
+        # All RAM rows report the same total, so the row must be disambiguated by
+        # lowest hrStorageIndex — ranking by total silently picks an arbitrary row.
+        agg = mock_es.search.call_args_list[-1].kwargs['aggregations']
+        top_hits = agg['by_poll']['aggregations']['physical']['top_hits']
+        assert top_hits['sort'] == [{'system.filesystem.index': {'order': 'asc'}}]
+        assert top_hits['size'] == 1
+
+    def test_metrics_queries_are_scoped_to_the_device(self, test_device):
+        """Every metrics query must filter to this device, not the whole fleet."""
+        from SNMP.snmp_crud import _get_device_metrics
+
+        captured = []
+        mock_es = MagicMock()
+        mock_es.search.side_effect = self._search_stub({
+            'metrics': [{'_source': {
+                '@timestamp': '2026-08-04T01:00:00Z',
+                'system': {'cpu': {'total': {'norm': {'pct': 0.25}}}},
+            }}],
+            'system.filesystem': [],
+        }, captured)
+
+        _get_device_metrics(test_device, mock_es)
+
+        assert captured, "expected at least one query"
+        for filters in captured:
+            assert {"term": {"host.polled_address": test_device.ip_address}} in filters
+            assert {"range": {"@timestamp": {"gte": "now-6h"}}} in filters
+
+    def test_uptime_defaults_to_zero_without_metrics_docs(self, test_device):
+        """No metrics documents must not raise."""
+        from SNMP.snmp_crud import _get_device_metrics
+
+        mock_es = MagicMock()
+        mock_es.search.side_effect = self._search_stub({})
+
+        metrics = _get_device_metrics(test_device, mock_es)
+
+        assert metrics['Uptime'] == 0
+        assert metrics['CPU'] == []
+        assert metrics['Memory'] == []


### PR DESCRIPTION
Three defects left the expanded device panel reporting nothing while the data was present in Elasticsearch.

- **CPU chart blank.** CPU and memory were read from one document under a single `try`, so a device deriving no memory percentage lost its CPU samples too. Now collected independently.

- **Memory chart blank on HOST-RESOURCES-only profiles.** Those derive no `system.memory.actual.used.pct`. Memory now falls back to the `hrStorageRam` row of `hrStorageTable` when the canonical field is absent — selected by `hrStorageType`, not the agent- and locale-specific description (`RAM` on EOS, `Physical memory` on net-snmp). Every RAM row reports the same total, so the physical row is picked by lowest `hrStorageIndex`; ranking by total silently selects a cache or buffers row. Aggregating per poll also avoids a `size` cap that truncated the series once multiplied by the number of RAM rows. That figure counts reclaimable cache, so the response reports `MemorySource` and the chart is labelled accordingly. Profiles that *do* derive the canonical field (UCD, Cisco, Brocade, ONT) continue to use it.

- **Interfaces grey with zeroed counters.** OpenConfig-shaped documents nest admin/oper status under `interface.state` and traffic counters one level deeper under `state.counters`, while the UI reads both off the interface object. Both levels are now flattened, with existing top-level values winning so a pipeline-normalized `"UP"` is not overwritten by a raw enum the UI would render as "Unknown".

## Verification

Checked against live data for four devices: the two on profiles deriving the canonical field keep using it, and the two on HOST-RESOURCES-MIB now resolve the physical RAM row. Interface counters resolve to real traffic, including a link reporting an input error that previously rendered as zero.

584 tests pass, including 8 new regression tests covering source preference, the RAM-row selection, device scoping, and the flatten merge order.

## Follow-up, not addressed here

`network_map.py::get_edge_interface_detail` returns `interface` raw/unflattened while its consumer reads the same flat fields — the same latent defect at a second endpoint. Left out of scope to keep this change focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)