### PR TITLE
fix(snmp): decode the ES API key for both Logstash consumers, not just one

### DIFF
--- a/src/logstashui/SNMP/snmp_pipeline_generator.py
+++ b/src/logstashui/SNMP/snmp_pipeline_generator.py
@@ -5,6 +5,7 @@
 from django.conf import settings
 import os
 import re
+import base64
 import ipaddress
 import logging
 import json
@@ -74,6 +75,31 @@ def _es_api_key_name(connection):
     return f"snmp_es_{connection.id}_api_key"
 
 
+def es_plaintext_api_key(connection):
+    """
+    Return an ES connection's API key in the plain "id:secret" form Logstash needs.
+
+    The Elastic API issues — and LogstashUI stores — the key base64-encoded as
+    base64("id:secret"). The Logstash `elasticsearch` plugin requires the decoded
+    form: handed the encoded blob it returns HTTP 401 on every bulk request, so a
+    pipeline deploys cleanly and then indexes zero documents.
+
+    Both consumers must normalize: the inline `api_key` setting AND the keystore
+    entry the Agent path provisions (a reference resolves to whatever was stored).
+    Decoding lives here, once, so a future refactor cannot drop it at one site and
+    keep it at the other — which is exactly how it regressed before.
+
+    Falls back to the raw value when it is not base64, or decodes to something
+    without a colon (i.e. already plain, or a format we do not recognise).
+    """
+    raw = connection.get_api_key() or ""
+    try:
+        decoded = base64.b64decode(raw).decode("utf-8")
+    except Exception:
+        return raw
+    return decoded if ":" in decoded else raw
+
+
 def _es_user_key_name(connection):
     """Keystore key name holding an ES connection username."""
     return f"snmp_es_{connection.id}_user"
@@ -132,7 +158,7 @@ def es_connection_keystore_entries(connection):
         return entries
 
     if connection.api_key:
-        api_key = connection.get_api_key()
+        api_key = es_plaintext_api_key(connection)
         if api_key:
             entries[_es_api_key_name(connection)] = api_key
     elif connection.username and connection.password:
@@ -1024,7 +1050,7 @@ def _generate_output(network_db_object, snmp_type="polling", device_template=Non
             config["password"] = _ref(_es_password_key_name(connection))
     else:
         if connection.api_key:
-            config["api_key"] = connection.get_api_key()
+            config["api_key"] = es_plaintext_api_key(connection)
         elif connection.username and connection.password:
             config["user"] = connection.username
             config["password"] = connection.get_password()

--- a/src/logstashui/SNMP/tests/test_snmp_pipeline_generator.py
+++ b/src/logstashui/SNMP/tests/test_snmp_pipeline_generator.py
@@ -7,6 +7,7 @@ Tests for SNMP.snmp_pipeline_generator — pure utility functions that require
 no database or network access.
 """
 
+import base64
 import pytest
 from unittest.mock import MagicMock
 
@@ -18,6 +19,7 @@ from SNMP.snmp_pipeline_generator import (
     _auth_pass_key_name,
     _priv_pass_key_name,
     _es_api_key_name,
+    es_plaintext_api_key,
     _es_user_key_name,
     _es_password_key_name,
     _ref,
@@ -428,6 +430,19 @@ class TestEsConnectionKeystoreEntries:
         assert entries['snmp_es_2_user'] == 'elastic'
         assert entries['snmp_es_2_password'] == 'secret'
 
+    def test_keystore_entry_is_decoded_not_the_stored_blob(self):
+        """
+        The Agent path provisions the keystore itself, so the value it writes is
+        what Logstash ultimately resolves. Storing the base64 blob here 401s just
+        as surely as embedding it inline.
+        """
+        conn = self._conn(3, api_key='encrypted_key', username=None, password=None)
+        conn.get_api_key.return_value = base64.b64encode(
+            b'AbCdEf123:xyz-secret-value'
+        ).decode()
+        entries = es_connection_keystore_entries(conn)
+        assert entries['snmp_es_3_api_key'] == 'AbCdEf123:xyz-secret-value'
+
     def test_no_credentials_returns_empty(self):
         conn = self._conn(3, api_key=None, username='', password='')
         entries = es_connection_keystore_entries(conn)
@@ -632,3 +647,44 @@ class TestGenerateSnmpErrorCleanupFilter:
         result = _generate_snmp_error_cleanup_filter()
         code = result['config']['code']
         assert 'error' in code.lower()
+
+
+# ===========================================================================
+# es_plaintext_api_key
+# ===========================================================================
+
+class TestEsPlaintextApiKey:
+    """
+    Logstash's elasticsearch output requires a plain "id:secret" API key. The
+    Elastic API issues, and LogstashUI stores, base64("id:secret"). Handed the
+    encoded blob the plugin returns 401 on every bulk request, so the pipeline
+    deploys cleanly and indexes nothing.
+
+    This regressed once already: the decode was applied in snmp_crud.py, then
+    dropped when _generate_output moved into this module. These tests exist so a
+    refactor cannot silently lose it again.
+    """
+
+    def _conn(self, raw):
+        c = MagicMock()
+        c.id = 1
+        c.get_api_key.return_value = raw
+        return c
+
+    def test_decodes_base64_to_id_colon_secret(self):
+        encoded = base64.b64encode(b'AbCdEf123:xyz-secret-value').decode()
+        assert es_plaintext_api_key(self._conn(encoded)) == 'AbCdEf123:xyz-secret-value'
+
+    def test_already_plain_key_is_passed_through(self):
+        assert es_plaintext_api_key(self._conn('AbCdEf123:xyz')) == 'AbCdEf123:xyz'
+
+    def test_base64_without_a_colon_is_passed_through(self):
+        """Decodes cleanly but is not an id:secret pair — not ours to rewrite."""
+        encoded = base64.b64encode(b'no-colon-here').decode()
+        assert es_plaintext_api_key(self._conn(encoded)) == encoded
+
+    def test_non_base64_is_passed_through(self):
+        assert es_plaintext_api_key(self._conn('not!valid!base64')) == 'not!valid!base64'
+
+    def test_none_becomes_empty_string(self):
+        assert es_plaintext_api_key(self._conn(None)) == ''


### PR DESCRIPTION
## The bug

Logstash's `elasticsearch` output requires a plain `id:secret` API key. The Elastic API issues — and LogstashUI stores — `base64("id:secret")`. Handed the encoded blob, the plugin returns **HTTP 401 on every bulk request**, so a pipeline deploys cleanly and then indexes zero documents. It looks like a working deployment.

## Why it needs fixing in two places

This was fixed once in `snmp_crud.py`, then lost when `_generate_output` moved into `snmp_pipeline_generator.py` — the decode didn't come with it.

Since that move the file has grown a **second** consumer. `es_connection_keystore_entries()` provisions the Logstash keystore for the Agent deploy path:

```python
if connection.api_key:
    api_key = connection.get_api_key()      # stores the encoded blob
    entries[_es_api_key_name(connection)] = api_key
```

In Agent mode `_generate_output` emits only a reference (`${snmp_es_1_api_key}`), which *looks* safe — but it resolves to whatever the keystore holds. So both paths hand Logstash the same unusable value by different routes, and a fix applied only to the inline site would leave **every Agent-mode deployment still 401ing**. (`_uses_keystore`: Agent mode always; Centralized mode when `credential_mode == 'KEYSTORE'`.)

Worth noting the docstring already promises `{key_name: plaintext_value}` — this makes it true for API keys.

## The change

One helper, `es_plaintext_api_key()`, called by both consumers, so a future refactor of either site can't drop the decode at one and keep it at the other:

```python
def es_plaintext_api_key(connection):
    raw = connection.get_api_key() or ""
    try:
        decoded = base64.b64decode(raw).decode("utf-8")
    except Exception:
        return raw
    return decoded if ":" in decoded else raw
```

Keys that are already plain, decode without a colon, or aren't valid base64 pass through untouched — no behaviour change for those.

## Verification

- **590 SNMP tests pass.**
- Six new tests: five on the helper (decode + three pass-through paths + `None`), one asserting the keystore entry carries the decoded value.
- **Mutation-verified, both directions:**
  - Helper reverted to returning the raw blob → exactly 2 tests red (decode + keystore), 100 still passing, so the suite ran rather than aborting early.
  - **Only the keystore call site** reverted, helper intact → exactly 1 test red, the keystore one. That's the assertion that matters: it proves the second path is covered independently rather than riding on the first.
- The existing `test_api_key_preferred` still passes — its mock value `myapikey` fails `b64decode().decode()` and takes the pass-through branch.

## One thing for the reviewer to decide

This changes what LogstashUI **writes into** keystores. Deployments already provisioned with the encoded blob won't self-correct — they'll carry the bad value until re-provisioned. I haven't traced whether the Agent deploy path rewrites entries on every deploy or only on create; if it's create-only, existing Agent deployments may need a manual re-provision to pick this up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)