### PR TITLE
Fix/stop ls and snmp hostname bug

### DIFF
--- a/src/logstashui/PipelineManager/agent_modes.py
+++ b/src/logstashui/PipelineManager/agent_modes.py
@@ -369,13 +369,17 @@ def probe_embedded_agent_online(timeout: float = 2.0) -> bool:
         return False
 
 
-def ensure_embedded_connection() -> Connection | None:
+def ensure_embedded_connection(*, probe: bool = True) -> Connection | None:
     """
     Ensure a pseudo Connection exists for the system Embedded Policy so the
     editor picker can list docker/local embedded agent without enrollment.
 
     Host/port derived from settings.LOGSTASH_AGENT_URL when possible.
-    Probes the agent and updates last_check_in so Connection Manager shows online.
+
+    The live HTTP probe updates last_check_in for online status. Page-render
+    paths that only need the sticky row must pass probe=False; Connection
+    Manager / SSE / inspect (and a background thread on editor load) keep
+    the default so the DB entry still gets refreshed.
     """
     try:
         from datetime import datetime, timezone
@@ -396,7 +400,7 @@ def ensure_embedded_connection() -> Connection | None:
         parsed = urlparse(agent_url)
         host = parsed.hostname or "127.0.0.1"
         port = parsed.port or EMBEDDED_AGENT_API_PORT
-        online = probe_embedded_agent_online()
+        online = probe_embedded_agent_online() if probe else False
         now = datetime.now(timezone.utc)
 
         conn = Connection.objects.filter(
@@ -455,6 +459,16 @@ def ensure_embedded_connection() -> Connection | None:
         return None
 
 
+def refresh_embedded_connection_async():
+    """Probe embedded agent and update last_check_in without blocking the caller."""
+    try:
+        import threading
+
+        threading.Thread(target=ensure_embedded_connection, daemon=True).start()
+    except Exception:
+        pass
+
+
 def is_embedded_connection(conn) -> bool:
     """True for the docker/local pseudo agent (dict or model)."""
     if conn is None:
@@ -475,9 +489,13 @@ def is_embedded_connection(conn) -> bool:
 def list_simulation_targets(active_only: bool = True, *, ensure_embedded: bool = True):
     """
     Return list of dicts describing simulate-capable connections for the editor.
+
+    When ensure_embedded is True, the sticky embedded Connection row is created
+    if missing. The live agent probe is skipped here so editor listing does not
+    block on an unreachable embedded agent.
     """
     if ensure_embedded:
-        ensure_embedded_connection()
+        ensure_embedded_connection(probe=False)
 
     qs = Connection.objects.filter(
         connection_type=Connection.ConnectionType.AGENT,

--- a/src/logstashui/PipelineManager/editor_views.py
+++ b/src/logstashui/PipelineManager/editor_views.py
@@ -55,8 +55,13 @@ def _parse_queue_max_bytes(queue_max_bytes_str):
 
 def PipelineEditor(request):
     from django.conf import settings
-    from PipelineManager.agent_modes import list_simulation_targets
+    from PipelineManager.agent_modes import (
+        list_simulation_targets,
+        refresh_embedded_connection_async,
+    )
 
+    # Keep last_check_in fresh without blocking HTML on the live HTTP probe.
+    refresh_embedded_connection_async()
     sim_targets = list_simulation_targets(ensure_embedded=True)
     selected_sim = request.session.get("sim_connection_id")
     if selected_sim is not None and not any(

--- a/src/logstashui/PipelineManager/manager_views.py
+++ b/src/logstashui/PipelineManager/manager_views.py
@@ -76,13 +76,12 @@ def PipelineManager(request):
     """Builds the table of pipelines"""
     context = {}
     # Refresh sticky embedded row (probe + last_check_in) in the background.
-    # The probe is a blocking HTTP call; running it in a daemon thread means the
-    # page renders immediately and the SSE stream picks up the result shortly after.
+    # The probe is a blocking HTTP call; a daemon thread means the page renders
+    # immediately and the SSE stream picks up the result shortly after.
     try:
-        import threading
-        from PipelineManager.agent_modes import ensure_embedded_connection
+        from PipelineManager.agent_modes import refresh_embedded_connection_async
 
-        threading.Thread(target=ensure_embedded_connection, daemon=True).start()
+        refresh_embedded_connection_async()
     except Exception:
         pass
 

--- a/src/logstashui/PipelineManager/static/js/pipeline_editor.js
+++ b/src/logstashui/PipelineManager/static/js/pipeline_editor.js
@@ -874,14 +874,40 @@ function triggerPipelineWarmingAndChecking(opts) {
     // Target-switch / explicit re-warm: use fetch path with Warming chip (reliable)
     const useFetchWarm = !!options.useFetch || force;
 
+    // Config / target change: ALWAYS clear the session slot before any early returns so
+    // that Run is forced to re-allocate even when we skip the embedded pre-warm below.
+    // Failing to clear here means the backend receives a stale slot_id, skips allocate
+    // entirely (use_session_slot=True), and the agent never sees the updated pipeline config.
+    if (!soft || force) {
+        if (typeof window.clearSimulationSessionSlot === 'function') {
+            window.clearSimulationSessionSlot(force ? 'force re-warm' : 'config change');
+        } else {
+            window.simulationSessionSlotId = null;
+            window.simulationSessionConnectionId = null;
+            window.currentSlotId = null;
+            if (typeof currentSlotId !== 'undefined') {
+                currentSlotId = null;
+            }
+        }
+    }
+
     // Component-edit warming is host/simulate only; page-open always warms when filters exist.
     // Force always runs (e.g. sim target switch to embedded).
+    // Slot was already cleared above — embedded mode skips the pre-warm, not the invalidation.
     if (
         !fromPageLoad &&
         !force &&
         typeof simulationMode !== 'undefined' &&
         simulationMode === 'embedded'
     ) {
+        // Reset the chip to Unallocated so the user can see the slot is stale and will
+        // be re-allocated on the next Run (otherwise it stays green "✓ Slot 1" which is
+        // misleading — the session slot variable is null at this point).
+        if (typeof window.setPipelineSlotChip === 'function') {
+            window.setPipelineSlotChip('unallocated', {
+                title: 'Pipeline changed — will re-allocate on next Run',
+            });
+        }
         return;
     }
 
@@ -898,20 +924,6 @@ function triggerPipelineWarmingAndChecking(opts) {
 
     if ((_pipelineWarmInFlight || window.__slotPreallocInFlight) && soft && !force) {
         return;
-    }
-
-    // Config / target change: clear previous session slot so Run does not reuse stale state
-    if (!soft || force) {
-        if (typeof window.clearSimulationSessionSlot === 'function') {
-            window.clearSimulationSessionSlot(force ? 'force re-warm' : 'config change');
-        } else {
-            window.simulationSessionSlotId = null;
-            window.simulationSessionConnectionId = null;
-            window.currentSlotId = null;
-            if (typeof currentSlotId !== 'undefined') {
-                currentSlotId = null;
-            }
-        }
     }
 
     // Check if there are any filter components

--- a/src/logstashui/PipelineManager/tests/test_agent_modes.py
+++ b/src/logstashui/PipelineManager/tests/test_agent_modes.py
@@ -426,6 +426,36 @@ def test_ensure_embedded_connection(system_policies, settings, monkeypatch):
     assert conn2.last_check_in is not None
 
 
+def test_ensure_embedded_connection_skip_probe(system_policies, settings, monkeypatch):
+    """Listing/page render must not wait on the live HTTP probe."""
+    settings.LOGSTASH_AGENT_URL = 'https://logstashagent:9500'
+    probed = {'called': False}
+
+    def _probe(timeout=2.0):
+        probed['called'] = True
+        return True
+
+    monkeypatch.setattr('PipelineManager.agent_modes.probe_embedded_agent_online', _probe)
+    conn = ensure_embedded_connection(probe=False)
+    assert conn is not None
+    assert conn.agent_id == 'embedded-local'
+    assert probed['called'] is False
+    assert conn.last_check_in is None
+
+
+def test_list_simulation_targets_does_not_probe(system_policies, monkeypatch):
+    """Editor listing must not block on an unreachable embedded agent."""
+    probed = {'called': False}
+
+    def _probe(timeout=2.0):
+        probed['called'] = True
+        return True
+
+    monkeypatch.setattr('PipelineManager.agent_modes.probe_embedded_agent_online', _probe)
+    list_simulation_targets(ensure_embedded=True)
+    assert probed['called'] is False
+
+
 def test_build_policy_config_simulate_paths_use_logstash_agent_root(system_policies):
     from PipelineManager.agent_modes import build_policy_config, SIMULATE_ROOT
     from PipelineManager.models import Policy

--- a/src/logstashui/PipelineManager/tests/test_agent_modes.py
+++ b/src/logstashui/PipelineManager/tests/test_agent_modes.py
@@ -532,6 +532,36 @@ def test_ensure_embedded_connection(system_policies, settings, monkeypatch):
     assert conn2.last_check_in is not None
 
 
+def test_ensure_embedded_connection_skip_probe(system_policies, settings, monkeypatch):
+    """Listing/page render must not wait on the live HTTP probe."""
+    settings.LOGSTASH_AGENT_URL = 'https://logstashagent:9500'
+    probed = {'called': False}
+
+    def _probe(timeout=2.0):
+        probed['called'] = True
+        return True
+
+    monkeypatch.setattr('PipelineManager.agent_modes.probe_embedded_agent_online', _probe)
+    conn = ensure_embedded_connection(probe=False)
+    assert conn is not None
+    assert conn.agent_id == 'embedded-local'
+    assert probed['called'] is False
+    assert conn.last_check_in is None
+
+
+def test_list_simulation_targets_does_not_probe(system_policies, monkeypatch):
+    """Editor listing must not block on an unreachable embedded agent."""
+    probed = {'called': False}
+
+    def _probe(timeout=2.0):
+        probed['called'] = True
+        return True
+
+    monkeypatch.setattr('PipelineManager.agent_modes.probe_embedded_agent_online', _probe)
+    list_simulation_targets(ensure_embedded=True)
+    assert probed['called'] is False
+
+
 def test_build_policy_config_simulate_paths_use_logstash_agent_root(system_policies):
     from PipelineManager.agent_modes import build_policy_config, SIMULATE_ROOT
     from PipelineManager.models import Policy

--- a/src/logstashui/SNMP/snmp_crud.py
+++ b/src/logstashui/SNMP/snmp_crud.py
@@ -1533,6 +1533,13 @@ def GetDeployDiff(request):
         network_pipeline_map = {}
 
         for network in networks:
+            # Agent-mode pipelines live in Django, but they still write metrics
+            # to Elasticsearch. The index-template panel is keyed off this map,
+            # so Agent networks must contribute their ES connection or a
+            # fresh Agent-only install never prompts to install the template.
+            if network.connection:
+                connection_name_map[network.connection.id] = network.connection.name
+
             # Agent-mode networks are reconciled against Django Pipeline records,
             # not Elasticsearch CPM. Handled in a dedicated section below.
             if network.deployment_mode == 'AGENT':
@@ -1541,7 +1548,6 @@ def GetDeployDiff(request):
                 conn_id = network.connection.id
                 if conn_id not in pipeline_names_by_connection:
                     pipeline_names_by_connection[conn_id] = []
-                connection_name_map[conn_id] = network.connection.name
 
                 # Get unique templates for this network
                 devices = network.devices.all()
@@ -4239,17 +4245,23 @@ def get_devices_online_batch(devices):
         try:
             es = get_elastic_connection(connection_id)
 
-            # Each device is polled by hostname (if set) or IP - that value is
-            # stored verbatim in host.polled_address
+            # Each device is polled by hostname (if set) or IP — that value is
+            # stored verbatim in host.polled_address (a keyword TSDS dimension).
             poll_addresses = [d.hostname or d.ip_address for d in device_list if d.hostname or d.ip_address]
-            addr_to_device = {(d.hostname or d.ip_address): d for d in device_list if d.hostname or d.ip_address}
 
             if not poll_addresses:
                 for device in device_list:
                     results[device.id] = False
                 continue
 
+            # Must target metrics-snmp* only: TSDS backing indices cannot be
+            # searched together with regular indices (the default _search).
+            # Aggregate on host.polled_address itself — it is already keyword
+            # (and a TSDS dimension). The .keyword multi-field is not present
+            # unless our custom template was applied, so using it fails on a
+            # fresh cluster and the exception was previously swallowed as "offline".
             search_results = es.search(
+                index="metrics-snmp*",
                 size=0,
                 query={
                     "bool": {
@@ -4272,7 +4284,7 @@ def get_devices_online_batch(devices):
                 aggregations={
                     "online_devices": {
                         "terms": {
-                            "field": "host.polled_address.keyword",
+                            "field": "host.polled_address",
                             "size": len(poll_addresses)
                         }
                     }
@@ -4289,6 +4301,10 @@ def get_devices_online_batch(devices):
                 results[device.id] = addr in online_addresses if addr else False
 
         except Exception as e:
+            logger.warning(
+                "Device online-status query failed for connection %s: %s",
+                connection_id, e,
+            )
             # If query fails, mark all devices on this connection as offline
             for device in device_list:
                 results[device.id] = False

--- a/src/logstashui/SNMP/snmp_crud.py
+++ b/src/logstashui/SNMP/snmp_crud.py
@@ -1956,8 +1956,8 @@ def GetDeployDiff(request):
                 policy = network.agent_connection.policy if network.agent_connection else None
                 if not policy:
                     _add_block(
-                        f"Network '{network.name}' is in Agent mode but is not assigned to an "
-                        f"agent policy. Please assign an agent before deploying."
+                        f"Network '{network.name}' is in Agent mode but does not have an agent "
+                        f"assigned to it. Please go to Networks and assign an agent to this policy."
                     )
                 elif not policy.keystore_password:
                     _add_block(

--- a/src/logstashui/SNMP/snmp_test.py
+++ b/src/logstashui/SNMP/snmp_test.py
@@ -10,6 +10,7 @@ from Common.formatters import format_display_name
 import json
 import logging
 import os
+import socket
 import traceback
 
 logger = logging.getLogger(__name__)
@@ -34,6 +35,46 @@ from pysnmp.hlapi.v3arch.asyncio import (
     usmAesCfb256Protocol,
 )
 import asyncio
+
+
+def _device_poll_address(device):
+    """Return the address used by generated SNMP polling pipelines."""
+    return device.hostname or device.ip_address
+
+
+def _resolve_device_poll_address(device):
+    """Resolve a hostname locally, falling back to the stored IP when possible."""
+    if not device.hostname:
+        return device.ip_address, None
+
+    try:
+        socket.getaddrinfo(device.hostname, device.port, type=socket.SOCK_DGRAM)
+        return device.hostname, None
+    except socket.gaierror:
+        warning = (
+            f"The machine running LogstashUI cannot resolve hostname "
+            f"'{device.hostname}'."
+        )
+        if device.ip_address:
+            return (
+                device.ip_address,
+                f"{warning} Falling back to IP address {device.ip_address}.",
+            )
+        raise ValueError(
+            f"{warning} No fallback IP address is configured for this device."
+        )
+
+
+def _device_response_data(device, poll_address=None):
+    """Serialize device addressing consistently for SNMP test responses."""
+    return {
+        'id': device.id,
+        'name': device.name,
+        'address': poll_address or _device_poll_address(device),
+        'hostname': device.hostname,
+        'ip_address': device.ip_address,
+        'port': device.port,
+    }
 
 
 def _format_snmp_value(value):
@@ -187,7 +228,7 @@ def _create_auth_data(credential):
     raise ValueError(f"Unknown SNMP version: {credential.version}")
 
 
-async def _perform_snmp_get_async(device, credential, oids):
+async def _perform_snmp_get_async(device, credential, oids, poll_address=None):
     """Perform SNMP GET operations (async)"""
     results = {}
     
@@ -199,7 +240,9 @@ async def _perform_snmp_get_async(device, credential, oids):
     except Exception as e:
         return {'error': f'Failed to create authentication data: {str(e)}'}
     
-    transport = await UdpTransportTarget.create((device.ip_address, device.port))
+    transport = await UdpTransportTarget.create(
+        (poll_address or _device_poll_address(device), device.port)
+    )
     snmp_engine = SnmpEngine()  # Reuse the same engine
     
     for field_name, oid_string in oids.items():
@@ -224,7 +267,7 @@ async def _perform_snmp_get_async(device, credential, oids):
     
     return results
 
-def _perform_snmp_get(device, credential, oids):
+def _perform_snmp_get(device, credential, oids, poll_address=None):
     """Synchronous wrapper - runs async code in a thread"""
     import threading
     result = [None]  # Use list to allow modification in nested function
@@ -234,7 +277,9 @@ def _perform_snmp_get(device, credential, oids):
         try:
             loop = asyncio.new_event_loop()
             asyncio.set_event_loop(loop)
-            result[0] = loop.run_until_complete(_perform_snmp_get_async(device, credential, oids))
+            result[0] = loop.run_until_complete(
+                _perform_snmp_get_async(device, credential, oids, poll_address)
+            )
             # Cancel all pending tasks before closing
             pending = asyncio.all_tasks(loop)
             for task in pending:
@@ -259,7 +304,7 @@ def _perform_snmp_get(device, credential, oids):
     return result[0] if result[0] is not None else {'error': 'No response from device'}
 
 
-async def _perform_snmp_walk_async(device, credential, oids):
+async def _perform_snmp_walk_async(device, credential, oids, poll_address=None):
     """Perform SNMP WALK operations (async)"""
     results = {}
     
@@ -271,7 +316,9 @@ async def _perform_snmp_walk_async(device, credential, oids):
     except Exception as e:
         return {'error': f'Failed to create authentication data: {str(e)}'}
     
-    transport = await UdpTransportTarget.create((device.ip_address, device.port))
+    transport = await UdpTransportTarget.create(
+        (poll_address or _device_poll_address(device), device.port)
+    )
     snmp_engine = SnmpEngine()  # Reuse the same engine
     
     for field_name, oid_string in oids.items():
@@ -323,7 +370,7 @@ async def _perform_snmp_walk_async(device, credential, oids):
     
     return results
 
-def _perform_snmp_walk(device, credential, oids):
+def _perform_snmp_walk(device, credential, oids, poll_address=None):
     """Synchronous wrapper - runs async code in a thread"""
     import threading
     result = [None]
@@ -333,7 +380,9 @@ def _perform_snmp_walk(device, credential, oids):
         try:
             loop = asyncio.new_event_loop()
             asyncio.set_event_loop(loop)
-            result[0] = loop.run_until_complete(_perform_snmp_walk_async(device, credential, oids))
+            result[0] = loop.run_until_complete(
+                _perform_snmp_walk_async(device, credential, oids, poll_address)
+            )
             # Cancel all pending tasks before closing
             pending = asyncio.all_tasks(loop)
             for task in pending:
@@ -356,7 +405,7 @@ def _perform_snmp_walk(device, credential, oids):
     
     return result[0] if result[0] is not None else {'error': 'No response from device'}
 
-async def _perform_snmp_table_async(device, credential, tables):
+async def _perform_snmp_table_async(device, credential, tables, poll_address=None):
     """Perform SNMP table operations (async)"""
     results = {}
     
@@ -368,7 +417,9 @@ async def _perform_snmp_table_async(device, credential, tables):
     except Exception as e:
         return {'error': f'Failed to create authentication data: {str(e)}'}
     
-    transport = await UdpTransportTarget.create((device.ip_address, device.port))
+    transport = await UdpTransportTarget.create(
+        (poll_address or _device_poll_address(device), device.port)
+    )
     snmp_engine = SnmpEngine()  # Reuse the same engine
     
     for table_name, table_config in tables.items():
@@ -423,7 +474,7 @@ async def _perform_snmp_table_async(device, credential, tables):
     
     return results
 
-def _perform_snmp_table(device, credential, tables):
+def _perform_snmp_table(device, credential, tables, poll_address=None):
     """Synchronous wrapper - runs async code in a thread"""
     import threading
     result = [None]
@@ -433,7 +484,9 @@ def _perform_snmp_table(device, credential, tables):
         try:
             loop = asyncio.new_event_loop()
             asyncio.set_event_loop(loop)
-            result[0] = loop.run_until_complete(_perform_snmp_table_async(device, credential, tables))
+            result[0] = loop.run_until_complete(
+                _perform_snmp_table_async(device, credential, tables, poll_address)
+            )
             # Cancel all pending tasks before closing
             pending = asyncio.all_tasks(loop)
             for task in pending:
@@ -504,6 +557,15 @@ def RunSNMPTest(request):
         logger.debug("Merging profile OIDs...")
         merged_oids = _merge_profile_oids(profiles)
         logger.debug(f"Merged OIDs - GET: {len(merged_oids['get'])}, WALK: {len(merged_oids['walk'])}, TABLE: {len(merged_oids['table'])}")
+
+        try:
+            poll_address, address_warning = _resolve_device_poll_address(device)
+        except ValueError as e:
+            return JsonResponse({
+                'success': False,
+                'error': str(e),
+                'device': _device_response_data(device),
+            }, status=400)
         
         logger.debug("Performing SNMP operations...")
         
@@ -515,9 +577,15 @@ def RunSNMPTest(request):
         def perform_all_operations():
             try:
                 results_container[0] = {
-                    'get': _perform_snmp_get(device, device.credential, merged_oids['get']),
-                    'walk': _perform_snmp_walk(device, device.credential, merged_oids['walk']),
-                    'table': _perform_snmp_table(device, device.credential, merged_oids['table'])
+                    'get': _perform_snmp_get(
+                        device, device.credential, merged_oids['get'], poll_address
+                    ),
+                    'walk': _perform_snmp_walk(
+                        device, device.credential, merged_oids['walk'], poll_address
+                    ),
+                    'table': _perform_snmp_table(
+                        device, device.credential, merged_oids['table'], poll_address
+                    )
                 }
             except Exception as e:
                 exception_container[0] = e
@@ -533,12 +601,8 @@ def RunSNMPTest(request):
                 'success': False,
                 'error': 'Test timed out after 60 seconds - device may be unreachable or too slow to respond',
                 'execution_time': 60.0,
-                'device': {
-                    'id': device.id,
-                    'name': device.name,
-                    'ip_address': device.ip_address,
-                    'port': device.port
-                },
+                'device': _device_response_data(device, poll_address),
+                'address_warning': address_warning,
                 'template': {
                     'id': template.id,
                     'name': template.name,
@@ -633,12 +697,8 @@ def RunSNMPTest(request):
                 'success': False,
                 'error': error_text,
                 'execution_time': round(execution_time, 2),
-                'device': {
-                    'id': device.id,
-                    'name': device.name,
-                    'ip_address': device.ip_address,
-                    'port': device.port
-                },
+                'device': _device_response_data(device, poll_address),
+                'address_warning': address_warning,
                 'template': {
                     'id': template.id,
                     'name': template.name,
@@ -658,12 +718,8 @@ def RunSNMPTest(request):
                 'success': False,
                 'error': error_text,
                 'execution_time': round(execution_time, 2),
-                'device': {
-                    'id': device.id,
-                    'name': device.name,
-                    'ip_address': device.ip_address,
-                    'port': device.port
-                },
+                'device': _device_response_data(device, poll_address),
+                'address_warning': address_warning,
                 'template': {
                     'id': template.id,
                     'name': template.name,
@@ -681,12 +737,8 @@ def RunSNMPTest(request):
             'has_errors': has_errors,
             'error_summary': '; '.join(list(dict.fromkeys(all_errors))) if all_errors else None,
             'execution_time': round(execution_time, 2),
-            'device': {
-                'id': device.id,
-                'name': device.name,
-                'ip_address': device.ip_address,
-                'port': device.port
-            },
+            'device': _device_response_data(device, poll_address),
+            'address_warning': address_warning,
             'template': {
                 'id': template.id,
                 'name': template.name,

--- a/src/logstashui/SNMP/static/js/snmp_test.js
+++ b/src/logstashui/SNMP/static/js/snmp_test.js
@@ -150,7 +150,7 @@ document.addEventListener('DOMContentLoaded', function() {
         deviceSelect.addEventListener('change', function() {
             const opt = this.options[this.selectedIndex];
             if (this.value) {
-                const ip = opt.dataset.ip;
+                const address = opt.dataset.address;
                 const port = opt.dataset.port;
                 const hasCredential = opt.dataset.hasCredential === 'true';
                 const templateId = opt.dataset.templateId;
@@ -160,7 +160,7 @@ document.addEventListener('DOMContentLoaded', function() {
                     deviceInfoText.classList.add('text-yellow-400');
                     deviceInfoText.classList.remove('text-gray-400');
                 } else {
-                    deviceInfoText.textContent = `${ip}:${port}`;
+                    deviceInfoText.textContent = `${address}:${port}`;
                     deviceInfoText.classList.remove('text-yellow-400');
                     deviceInfoText.classList.add('text-gray-400');
                 }
@@ -274,7 +274,7 @@ document.addEventListener('DOMContentLoaded', function() {
         errorState.classList.add('hidden');
 
         document.getElementById('snmpTestSummaryDevice').textContent =
-            `${data.device.name} (${data.device.ip_address}:${data.device.port})`;
+            `${data.device.name} (${data.device.address}:${data.device.port})`;
         document.getElementById('snmpTestSummaryTemplate').textContent = data.template.display_name || data.template.name;
 
         const executionTime = data.execution_time ? `${data.execution_time}s` : 'N/A';
@@ -283,7 +283,15 @@ document.addEventListener('DOMContentLoaded', function() {
             if (data.error_summary) {
                 statusHtml += `<br><span class="text-xs text-red-400 mt-1 block">${escapeHtml(data.error_summary)}</span>`;
             }
+            if (data.address_warning) {
+                statusHtml += `<br><span class="text-xs text-yellow-400 mt-1 block">${escapeHtml(data.address_warning)}</span>`;
+            }
             document.getElementById('snmpTestSummaryStatus').innerHTML = statusHtml;
+        } else if (data.address_warning) {
+            document.getElementById('snmpTestSummaryStatus').innerHTML =
+                `<span class="text-yellow-400">⚠ Success with IP Fallback</span><br>` +
+                `<span class="text-xs text-gray-400">Completed in ${executionTime}</span><br>` +
+                `<span class="text-xs text-yellow-400 mt-1 block">${escapeHtml(data.address_warning)}</span>`;
         } else {
             document.getElementById('snmpTestSummaryStatus').innerHTML =
                 `<span class="text-green-400">✓ Success</span><br><span class="text-xs text-gray-400">Completed in ${executionTime}</span>`;

--- a/src/logstashui/SNMP/templates/components/snmp_test_modal.html
+++ b/src/logstashui/SNMP/templates/components/snmp_test_modal.html
@@ -70,13 +70,13 @@
                 <option value="">-- Select a device --</option>
                 {% for device in devices %}
                 <option value="{{ device.id }}" 
-                        data-ip="{{ device.ip_address }}" 
+                        data-address="{{ device.hostname|default:device.ip_address }}"
                         data-port="{{ device.port }}"
                         data-template-id="{% if device.device_template %}{{ device.device_template.id }}{% endif %}"
                         data-template-name="{% if device.device_template %}{{ device.device_template.name }}{% endif %}"
                         data-template-display-name="{% if device.device_template %}{{ device.device_template.name|display_name }}{% endif %}"
                         data-has-credential="{% if device.credential %}true{% else %}false{% endif %}">
-                  {{ device.name }} ({{ device.ip_address }})
+                  {{ device.name }} ({{ device.hostname|default:device.ip_address }})
                 </option>
                 {% endfor %}
               </select>

--- a/src/logstashui/SNMP/tests/test_snmp_crud.py
+++ b/src/logstashui/SNMP/tests/test_snmp_crud.py
@@ -712,6 +712,54 @@ class TestDeployConfiguration:
             data = json.loads(response.content)
             assert data['success'] is True
             assert 'networks' in data
+            assert any(c['id'] == test_network.connection.id for c in data['connections'])
+
+    def test_get_deploy_diff_includes_es_connection_for_agent_only_networks(
+        self, authenticated_client, test_network, test_device, test_connection
+    ):
+        """Agent-only setups still need the SNMP index template on their ES connection."""
+        from PipelineManager.models import Policy, Connection as AgentConnection
+
+        policy = Policy.objects.create(
+            name='Simulated SNMP Policy',
+            settings_path='/etc/logstash/',
+            logs_path='/var/log/logstash',
+            binary_path='/usr/share/logstash/bin',
+            logstash_yml='http.host: "0.0.0.0"',
+            jvm_options='-Xms1g',
+            log4j2_properties='logger.logstash.name = logstash',
+            keystore_password='test_password',
+        )
+        agent = AgentConnection.objects.create(
+            name='SimulatedSNMP Agent',
+            connection_type='AGENT',
+            host='agent.example.com',
+            agent_id='sim-snmp-001',
+            is_active=True,
+            policy=policy,
+        )
+        test_network.deployment_mode = 'AGENT'
+        test_network.agent_connection = agent
+        test_network.save(update_fields=['deployment_mode', 'agent_connection'])
+
+        with patch('SNMP.snmp_crud.get_elastic_connection') as mock_es_conn:
+            mock_es = MagicMock()
+            mock_es.logstash.get_pipeline.return_value = {}
+            mock_es_conn.return_value = mock_es
+
+            response = authenticated_client.get('/SNMP/GetDeployDiff/')
+
+        assert response.status_code == 200
+        data = json.loads(response.content)
+        assert data['success'] is True
+        assert data['connections'] == [
+            {'id': test_connection.id, 'name': test_connection.name}
+        ]
+
+        # GetDeployDiff caches a 60s deploy plan; don't leak an Agent-mode plan
+        # into later DeployConfiguration tests in this class.
+        from django.core.cache import cache
+        cache.delete('snmp_deployment_plan')
 
     def test_deploy_configuration_requires_admin(self, readonly_client):
         """Test that deploying configuration requires admin role"""
@@ -768,6 +816,44 @@ class TestDeviceStatusAndVisualization:
         data = json.loads(response.content)
         assert data['success'] is True
         assert 'statuses' in data
+        assert data['statuses'][str(test_device.id)]['is_online'] is True
+
+        search_kwargs = mock_es.search.call_args.kwargs
+        assert search_kwargs['index'] == 'metrics-snmp*'
+        assert search_kwargs['aggregations']['online_devices']['terms']['field'] == 'host.polled_address'
+
+    @patch('SNMP.snmp_crud.get_elastic_connection')
+    def test_get_devices_status_hostname_only_device(
+        self, mock_es_conn, authenticated_client, test_network, test_credential_v2c
+    ):
+        """Hostname-only devices are matched on host.polled_address, not IP."""
+        device = Device.objects.create(
+            name='Linux',
+            hostname='linux_host.lab',
+            ip_address=None,
+            port=1161,
+            credential=test_credential_v2c,
+            network=test_network,
+        )
+        mock_es = MagicMock()
+        mock_es.search.return_value = {
+            'aggregations': {
+                'online_devices': {
+                    'buckets': [
+                        {'key': 'linux_host.lab', 'doc_count': 4}
+                    ]
+                }
+            }
+        }
+        mock_es_conn.return_value = mock_es
+
+        response = authenticated_client.get(f'/SNMP/GetDevicesStatus/?device_ids={device.id}')
+        assert response.status_code == 200
+        data = json.loads(response.content)
+        assert data['statuses'][str(device.id)]['is_online'] is True
+
+        terms_filter = mock_es.search.call_args.kwargs['query']['bool']['filter'][1]
+        assert terms_filter == {'terms': {'host.polled_address': ['linux_host.lab']}}
 
     def test_get_devices_status_invalid_ids(self, authenticated_client):
         """Test getting device status with invalid IDs"""

--- a/src/logstashui/SNMP/tests/test_snmp_test.py
+++ b/src/logstashui/SNMP/tests/test_snmp_test.py
@@ -8,12 +8,21 @@ RunSNMPTest / RunSNMPWalk view endpoints (SNMP network I/O mocked).
 """
 
 import json
+import socket
 import pytest
 from unittest.mock import patch, MagicMock
 from django.test import Client
 from django.contrib.auth.models import User
 
-from SNMP.snmp_test import _format_snmp_value, _create_auth_data, _load_profile_data, _merge_profile_oids
+from SNMP.snmp_test import (
+    _create_auth_data,
+    _device_poll_address,
+    _device_response_data,
+    _format_snmp_value,
+    _load_profile_data,
+    _merge_profile_oids,
+    _resolve_device_poll_address,
+)
 from SNMP.models import Device, DeviceTemplate, Profile, Credential, Network
 from PipelineManager.models import Connection
 from Management.models import UserProfile
@@ -276,6 +285,69 @@ class TestMergeProfileOids:
 
 
 # ===========================================================================
+# Device poll address
+# ===========================================================================
+
+class TestDevicePollAddress:
+
+    def test_hostname_is_preferred_over_ip_address(self):
+        device = MagicMock(
+            id=1,
+            name='switch-1',
+            hostname='switch-1.example.com',
+            ip_address='10.0.0.1',
+            port=161,
+        )
+
+        assert _device_poll_address(device) == 'switch-1.example.com'
+        assert _device_response_data(device)['address'] == 'switch-1.example.com'
+
+    def test_ip_address_is_used_when_hostname_is_empty(self):
+        device = MagicMock(hostname=None, ip_address='10.0.0.1')
+
+        assert _device_poll_address(device) == '10.0.0.1'
+
+    @patch('SNMP.snmp_test.socket.getaddrinfo')
+    def test_resolvable_hostname_is_used(self, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [(socket.AF_INET, socket.SOCK_DGRAM, 17, '', ('10.0.0.1', 161))]
+        device = MagicMock(
+            hostname='switch-1.example.com',
+            ip_address='10.0.0.1',
+            port=161,
+        )
+
+        address, warning = _resolve_device_poll_address(device)
+
+        assert address == 'switch-1.example.com'
+        assert warning is None
+
+    @patch('SNMP.snmp_test.socket.getaddrinfo', side_effect=socket.gaierror)
+    def test_unresolvable_hostname_falls_back_to_ip(self, mock_getaddrinfo):
+        device = MagicMock(
+            hostname='switch-1.example.com',
+            ip_address='10.0.0.1',
+            port=161,
+        )
+
+        address, warning = _resolve_device_poll_address(device)
+
+        assert address == '10.0.0.1'
+        assert 'cannot resolve' in warning
+        assert 'Falling back' in warning
+
+    @patch('SNMP.snmp_test.socket.getaddrinfo', side_effect=socket.gaierror)
+    def test_unresolvable_hostname_without_ip_raises_clear_error(self, mock_getaddrinfo):
+        device = MagicMock(
+            hostname='switch-1.example.com',
+            ip_address=None,
+            port=161,
+        )
+
+        with pytest.raises(ValueError, match='No fallback IP address'):
+            _resolve_device_poll_address(device)
+
+
+# ===========================================================================
 # _create_auth_data
 # ===========================================================================
 
@@ -466,7 +538,98 @@ class TestRunSNMPTestView:
         assert data['success'] is True
         assert 'results' in data
         assert data['device']['id'] == test_device.pk
+        assert data['device']['address'] == test_device.ip_address
         assert data['template']['name'] == test_device.device_template.name
+
+    @patch('SNMP.snmp_test._perform_snmp_get')
+    @patch('SNMP.snmp_test._perform_snmp_walk')
+    @patch('SNMP.snmp_test._perform_snmp_table')
+    def test_hostname_device_response_uses_hostname_as_poll_address(
+        self, mock_table, mock_walk, mock_get,
+        authenticated_client, test_device
+    ):
+        test_device.hostname = 'switch-1.example.com'
+        test_device.save(update_fields=['hostname'])
+        mock_get.return_value = {'sysDescr': 'Network switch'}
+        mock_walk.return_value = {}
+        mock_table.return_value = {}
+
+        with patch(
+            'SNMP.snmp_test._resolve_device_poll_address',
+            return_value=('switch-1.example.com', None),
+        ):
+            response = authenticated_client.post(
+                '/SNMP/RunSNMPTest/',
+                data=json.dumps({'device_id': test_device.pk}),
+                content_type='application/json'
+            )
+
+        assert response.status_code == 200
+        data = json.loads(response.content)
+        assert data['success'] is True
+        assert data['device']['address'] == 'switch-1.example.com'
+        assert data['device']['hostname'] == 'switch-1.example.com'
+        assert data['device']['ip_address'] == '10.0.0.1'
+
+    @patch('SNMP.snmp_test._perform_snmp_get')
+    @patch('SNMP.snmp_test._perform_snmp_walk')
+    @patch('SNMP.snmp_test._perform_snmp_table')
+    def test_unresolvable_hostname_falls_back_to_ip_and_returns_warning(
+        self, mock_table, mock_walk, mock_get,
+        authenticated_client, test_device
+    ):
+        test_device.hostname = 'switch-1.example.com'
+        test_device.save(update_fields=['hostname'])
+        mock_get.return_value = {'sysDescr': 'Network switch'}
+        mock_walk.return_value = {}
+        mock_table.return_value = {}
+
+        warning = (
+            "The machine running LogstashUI cannot resolve hostname "
+            "'switch-1.example.com'. Falling back to IP address 10.0.0.1."
+        )
+        with patch(
+            'SNMP.snmp_test._resolve_device_poll_address',
+            return_value=('10.0.0.1', warning),
+        ):
+            response = authenticated_client.post(
+                '/SNMP/RunSNMPTest/',
+                data=json.dumps({'device_id': test_device.pk}),
+                content_type='application/json'
+            )
+
+        data = json.loads(response.content)
+        assert data['success'] is True
+        assert data['device']['address'] == '10.0.0.1'
+        assert data['address_warning'] == warning
+        mock_get.assert_called_once_with(
+            test_device, test_device.credential,
+            test_device.device_template.profiles.first().profile_data['get'],
+            '10.0.0.1'
+        )
+
+    @patch('SNMP.snmp_test.socket.getaddrinfo', side_effect=socket.gaierror)
+    def test_unresolvable_hostname_only_device_returns_clear_error(
+        self, mock_getaddrinfo, authenticated_client, test_device
+    ):
+        test_device.hostname = 'switch-1.example.com'
+        test_device.ip_address = None
+        test_device.save(update_fields=['hostname', 'ip_address'])
+
+        response = authenticated_client.post(
+            '/SNMP/RunSNMPTest/',
+            data=json.dumps({'device_id': test_device.pk}),
+            content_type='application/json'
+        )
+
+        assert response.status_code == 400
+        data = json.loads(response.content)
+        assert data['success'] is False
+        assert data['error'] == (
+            "The machine running LogstashUI cannot resolve hostname "
+            "'switch-1.example.com'. No fallback IP address is configured "
+            "for this device."
+        )
 
     @patch('SNMP.snmp_test._perform_snmp_get')
     @patch('SNMP.snmp_test._perform_snmp_walk')


### PR DESCRIPTION
fix: resolved a bug where pipelines wouldn't warm for simulation after a pipeline change
fix: resolved a bug where we would not prompt the user to install the data stream template for SNMP if the connection wasn't via CPM. Now works for agents
fix: Fixed a bug where when performing SNMP tests, we would never try hostnames. So if a device was hostname only, it would never run the test. Added a fallback to IP address, along with improved error / notification handling to tell the user when DNS resolution fails for hostnames
fix: Fixed a bug where the connection probe resulted in every pipeline taking ~3 seconds to load, made that async
fix: Updated language in the SNMP deploy to be more concise when we are explaining that an agent isn't assigned to a network being deployed
fix: resolved a bug in the SNMP CRUD modals that resulted in an incorrect header on the Devices page whenever "Add Credential|Network" was selected
fix: made probe toward embedded sim node non-blocking
fix: updated start_logstashui.bat to mirror changes to start_logstashui.sh
fix: added both front end and back end validation for the namespace input to prevent using a namespace that Elastic will reject
fix: resolved issue that was preventing temp sensors and fans from appearing
fix(snmp): device panel showed no CPU/memory and grey interfaces
fix: isolate sim slots per agent and tolerate slow simulate forward