### PR TITLE
Fix CI test bin/test_databases.sh

### DIFF
--- a/bin/test_databases.sh
+++ b/bin/test_databases.sh
@@ -14,19 +14,11 @@ if ! command -v docker >/dev/null; then
   echo "Default pytest (SQLite) still works: uv run pytest" >&2
   exit 1
 fi
+
 uv sync --extra databases --group dev
-echo "==> SQLite pytest (no compose)"
-uv run pytest src/logstashui --no-cov
-echo "==> Starting Postgres / MariaDB / MySQL"
+
 "${COMPOSE[@]}" up -d --wait
-run_engine () {
-  local name="$1"; shift
-  echo "==> pytest on ${name}"
-  env "$@" uv run pytest src/logstashui --no-cov
-}
-run_engine postgresql LOGSTASHUI_DB_ENGINE=postgresql LOGSTASHUI_DB_HOST=127.0.0.1 LOGSTASHUI_DB_PORT=55432 LOGSTASHUI_DB_NAME=logstashui LOGSTASHUI_DB_USER=logstashui LOGSTASHUI_DB_PASSWORD=logstashui
-run_engine mariadb LOGSTASHUI_DB_ENGINE=mysql LOGSTASHUI_DB_HOST=127.0.0.1 LOGSTASHUI_DB_PORT=53306 LOGSTASHUI_DB_NAME=logstashui LOGSTASHUI_DB_USER=root LOGSTASHUI_DB_PASSWORD=logstashui
-run_engine mysql LOGSTASHUI_DB_ENGINE=mysql LOGSTASHUI_DB_HOST=127.0.0.1 LOGSTASHUI_DB_PORT=53307 LOGSTASHUI_DB_NAME=logstashui LOGSTASHUI_DB_USER=root LOGSTASHUI_DB_PASSWORD=logstashui
+
 echo "==> Database test suite (testcontainers)"
 uv run pytest tests/Database/ -v --no-cov
 if [[ "$KEEP" -eq 0 ]]; then "${COMPOSE[@]}" down -v; fi


### PR DESCRIPTION
This had some old artifacts in it pre-dating the migration of all tests to `$PROJECT_ROOT/tests` instead of nested in `src/` Removing the superfluous lines results in proper execution now.