### PR TITLE
Stop tracking scripts/.dependency_tracking.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -220,6 +220,9 @@ __marimo__/
 # Streamlit
 .streamlit/secrets.toml
 
+# CI related
+scripts/.dependency_tracking.txt
+
 # LogstashUI
 /src/logstashui/staticfiles/
 /src/logstashui/data/


### PR DESCRIPTION
It doesn't need to be in the repository